### PR TITLE
feat(CLAP-58): Marquee 컴포넌트 만들기

### DIFF
--- a/packages/service/src/Demo/pages/DemoPage.tsx
+++ b/packages/service/src/Demo/pages/DemoPage.tsx
@@ -5,6 +5,7 @@ import {
   ROTATE_DEMO_PAGE_ROUTE,
   SCROLL_DEMO_PAGE_ROUTE,
   SCROLL_TEXT_DEMO_PAGE_ROUTE,
+  MARQUEE_DEMO_PAGE_ROUTE,
 } from "../../constants/routes";
 
 const linkStyles = css`
@@ -44,6 +45,9 @@ export const DemoPage = () => {
       </Link>
       <Link to={SCROLL_TEXT_DEMO_PAGE_ROUTE} css={linkStyles}>
         스크롤 텍스트 데모
+      </Link>
+      <Link to={MARQUEE_DEMO_PAGE_ROUTE} css={linkStyles}>
+        마퀴 데모
       </Link>
     </div>
   );

--- a/packages/service/src/Demo/pages/MarqueeDemoPage.tsx
+++ b/packages/service/src/Demo/pages/MarqueeDemoPage.tsx
@@ -110,9 +110,6 @@ const reviews = [
   },
 ];
 
-const firstRow = reviews;
-const secondRow = reviews;
-
 export const MarqueeDemoPage = () => {
   return (
     <div
@@ -132,13 +129,18 @@ export const MarqueeDemoPage = () => {
         }
       `}
     >
-      <Marquee pauseOnHover duration={20}>
-        {firstRow.map((review) => (
+      <Marquee pauseOnHover duration={20} gap={32}>
+        {reviews.map((review) => (
           <ReviewCard key={review.username} {...review} />
         ))}
       </Marquee>
       <Marquee reverse pauseOnHover>
-        {secondRow.map((review) => (
+        {reviews.map((review) => (
+          <ReviewCard key={review.username} {...review} />
+        ))}
+      </Marquee>
+      <Marquee>
+        {reviews.map((review) => (
           <ReviewCard key={review.username} {...review} />
         ))}
       </Marquee>

--- a/packages/service/src/Demo/pages/MarqueeDemoPage.tsx
+++ b/packages/service/src/Demo/pages/MarqueeDemoPage.tsx
@@ -1,0 +1,147 @@
+import { css } from "@emotion/react";
+import { Marquee } from "@service/common/components/Marquee";
+
+interface ReviewCardProps {
+  img: string;
+  name: string;
+  username: string;
+  body: string;
+}
+
+export const ReviewCard = ({ img, name, username, body }: ReviewCardProps) => {
+  const cardStyles = css`
+    width: 20rem;
+    cursor: pointer;
+    overflow: hidden;
+    border-radius: 1rem;
+    border: 1px solid rgba(0, 0, 0, 0.1);
+    padding: 1rem;
+    background: rgba(0, 0, 0, 0.01);
+    &:hover {
+      background: rgba(0, 0, 0, 0.05);
+    }
+    .dark & {
+      border-color: rgba(255, 255, 255, 0.1);
+      background: rgba(255, 255, 255, 0.1);
+      &:hover {
+        background: rgba(255, 255, 255, 0.15);
+      }
+    }
+  `;
+
+  const headerStyles = css`
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    img {
+      border-radius: 50%;
+    }
+  `;
+
+  const textStyles = css`
+    display: flex;
+    flex-direction: column;
+    figcaption {
+      font-size: 0.875rem;
+      font-weight: 500;
+    }
+    p {
+      font-size: 0.75rem;
+      font-weight: 500;
+      color: rgba(255, 255, 255, 0.4);
+    }
+  `;
+
+  const bodyStyles = css`
+    margin-top: 0.5rem;
+    font-size: 0.875rem;
+  `;
+
+  return (
+    <figure css={cardStyles}>
+      <div css={headerStyles}>
+        <img src={img} alt="" width="32" height="32" />
+        <div css={textStyles}>
+          <figcaption>{name}</figcaption>
+          <p>{username}</p>
+        </div>
+      </div>
+      <blockquote css={bodyStyles}>{body}</blockquote>
+    </figure>
+  );
+};
+
+const reviews = [
+  {
+    name: "Jack",
+    username: "@jack",
+    body: "I've never seen anything like this before. It's amazing. I love it.",
+    img: "https://avatar.vercel.sh/jack",
+  },
+  {
+    name: "Jill",
+    username: "@jill",
+    body: "I don't know what to say. I'm speechless. This is amazing.",
+    img: "https://avatar.vercel.sh/jill",
+  },
+  {
+    name: "John",
+    username: "@john",
+    body: "I'm at a loss for words. This is amazing. I love it.",
+    img: "https://avatar.vercel.sh/john",
+  },
+  {
+    name: "Jane",
+    username: "@jane",
+    body: "I'm at a loss for words. This is amazing. I love it.",
+    img: "https://avatar.vercel.sh/jane",
+  },
+  {
+    name: "Jenny",
+    username: "@jenny",
+    body: "I'm at a loss for words. This is amazing. I love it.",
+    img: "https://avatar.vercel.sh/jenny",
+  },
+  {
+    name: "James",
+    username: "@james",
+    body: "I'm at a loss for words. This is amazing. I love it.",
+    img: "https://avatar.vercel.sh/james",
+  },
+];
+
+const firstRow = reviews;
+const secondRow = reviews;
+
+export const MarqueeDemoPage = () => {
+  return (
+    <div
+      css={css`
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        overflow: hidden;
+        border-radius: 0.5rem;
+        border: 1px solid gainsboro;
+        background: var(--background, #fff);
+        box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+        @media (min-width: 768px) {
+          box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
+        }
+      `}
+    >
+      <Marquee pauseOnHover duration={20}>
+        {firstRow.map((review) => (
+          <ReviewCard key={review.username} {...review} />
+        ))}
+      </Marquee>
+      <Marquee reverse pauseOnHover>
+        {secondRow.map((review) => (
+          <ReviewCard key={review.username} {...review} />
+        ))}
+      </Marquee>
+    </div>
+  );
+};

--- a/packages/service/src/Demo/pages/MarqueeDemoPage.tsx
+++ b/packages/service/src/Demo/pages/MarqueeDemoPage.tsx
@@ -8,7 +8,7 @@ interface ReviewCardProps {
   body: string;
 }
 
-export const ReviewCard = ({ img, name, username, body }: ReviewCardProps) => {
+const ReviewCard = ({ img, name, username, body }: ReviewCardProps) => {
   const cardStyles = css`
     width: 20rem;
     cursor: pointer;
@@ -129,19 +129,25 @@ export const MarqueeDemoPage = () => {
         }
       `}
     >
-      <Marquee pauseOnHover duration={20} gap={32}>
+      <Marquee pauseOnHover>
         {reviews.map((review) => (
-          <ReviewCard key={review.username} {...review} />
+          <Marquee.Item>
+            <ReviewCard key={review.username} {...review} />
+          </Marquee.Item>
         ))}
       </Marquee>
       <Marquee reverse pauseOnHover>
         {reviews.map((review) => (
-          <ReviewCard key={review.username} {...review} />
+          <Marquee.Item>
+            <ReviewCard key={review.username} {...review} />
+          </Marquee.Item>
         ))}
       </Marquee>
       <Marquee>
         {reviews.map((review) => (
-          <ReviewCard key={review.username} {...review} />
+          <Marquee.Item>
+            <ReviewCard key={review.username} {...review} />
+          </Marquee.Item>
         ))}
       </Marquee>
     </div>

--- a/packages/service/src/Main/pages/MainPage.tsx
+++ b/packages/service/src/Main/pages/MainPage.tsx
@@ -70,7 +70,7 @@ export const MainPage = () => {
           right: 20px;
         `}
       >
-        개발ㄴ
+        개발자
       </Link>
     </div>
   );

--- a/packages/service/src/common/components/Marquee/Marquee.css.ts
+++ b/packages/service/src/common/components/Marquee/Marquee.css.ts
@@ -38,7 +38,7 @@ export const MarqueeContainer = styled.div<{
     ${({ pauseOnHover }) =>
       pauseOnHover &&
       `
-      div.marquee-item {
+      div {
         animation-play-state: paused;
       }
     `}

--- a/packages/service/src/common/components/Marquee/Marquee.css.ts
+++ b/packages/service/src/common/components/Marquee/Marquee.css.ts
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
-import { keyframes, css } from "@emotion/react";
+import { keyframes } from "@emotion/react";
 
-const marqueeHorizontalAnimation = keyframes`
+const marqueeAnimation = keyframes`
   0% {
     transform: translateX(100%);
   }
@@ -10,52 +10,37 @@ const marqueeHorizontalAnimation = keyframes`
   }
 `;
 
-const marqueeVerticalAnimation = keyframes`
-  0% {
-    transform: translateY(100%);
-  }
-  100% {
-    transform: translateY(-100%);
-  }
-`;
-
 export const MarqueeItem = styled.div<{
-  vertical: boolean;
   reverse: boolean;
-  isPaused: boolean;
 }>`
   display: flex;
   flex-shrink: 0;
   justify-content: space-around;
   gap: var(--gap);
-  ${({ vertical }) => css`
-    animation: ${vertical
-        ? marqueeVerticalAnimation
-        : marqueeHorizontalAnimation}
-      var(--duration) linear infinite;
-  `}
+  animation: ${marqueeAnimation} var(--duration) linear infinite;
   animation-direction: ${({ reverse }) => (reverse ? "reverse" : "normal")};
-  animation-play-state: ${({ isPaused }) => (isPaused ? "paused" : "running")};
+  animation-play-state: running;
 `;
 
 export const MarqueeContainer = styled.div<{
-  vertical: boolean;
   pauseOnHover: boolean;
-  isPaused: boolean;
-  duration: number;
+  duration: string;
+  gap: string;
 }>`
   display: flex;
   overflow: hidden;
   padding: 2rem;
-  --duration: ${({ duration }) => `${duration}s`};
-  --gap: 1rem;
+  --duration: ${({ duration }) => duration};
+  --gap: ${({ gap }) => gap};
   gap: var(--gap);
-  flex-direction: ${({ vertical }) => (vertical ? "column" : "row")};
 
   &:hover {
-    .marquee-item {
-      animation-play-state: ${({ pauseOnHover }) =>
-        pauseOnHover ? "paused" : "running"};
-    }
+    ${({ pauseOnHover }) =>
+      pauseOnHover &&
+      `
+      div.marquee-item {
+        animation-play-state: paused;
+      }
+    `}
   }
 `;

--- a/packages/service/src/common/components/Marquee/Marquee.css.ts
+++ b/packages/service/src/common/components/Marquee/Marquee.css.ts
@@ -1,5 +1,14 @@
-import styled from "@emotion/styled";
-import { keyframes } from "@emotion/react";
+import { css, keyframes } from "@emotion/react";
+
+interface MarqueeItemStylesProps {
+  reverse: boolean;
+}
+
+interface MarqueeContainerStylesProps {
+  pauseOnHover: boolean;
+  duration: string;
+  gap: string;
+}
 
 const marqueeAnimation = keyframes`
   0% {
@@ -10,34 +19,31 @@ const marqueeAnimation = keyframes`
   }
 `;
 
-export const MarqueeItem = styled.div<{
-  reverse: boolean;
-}>`
+export const marqueeItemStyles = ({ reverse }: MarqueeItemStylesProps) => css`
   display: flex;
   flex-shrink: 0;
   justify-content: space-around;
   gap: var(--gap);
   animation: ${marqueeAnimation} var(--duration) linear infinite;
-  animation-direction: ${({ reverse }) => (reverse ? "reverse" : "normal")};
+  animation-direction: ${reverse ? "reverse" : "normal"};
   animation-play-state: running;
 `;
 
-export const MarqueeContainer = styled.div<{
-  pauseOnHover: boolean;
-  duration: string;
-  gap: string;
-}>`
+export const marqueeContainerStyles = ({
+  pauseOnHover,
+  duration,
+  gap,
+}: MarqueeContainerStylesProps) => css`
   display: flex;
   overflow: hidden;
   padding: 2rem;
-  --duration: ${({ duration }) => duration};
-  --gap: ${({ gap }) => gap};
+  --duration: ${duration};
+  --gap: ${gap};
   gap: var(--gap);
 
   &:hover {
-    ${({ pauseOnHover }) =>
-      pauseOnHover &&
-      `
+    ${pauseOnHover &&
+    `
       div {
         animation-play-state: paused;
       }

--- a/packages/service/src/common/components/Marquee/Marquee.css.ts
+++ b/packages/service/src/common/components/Marquee/Marquee.css.ts
@@ -1,0 +1,61 @@
+import styled from "@emotion/styled";
+import { keyframes, css } from "@emotion/react";
+
+const marqueeHorizontalAnimation = keyframes`
+  0% {
+    transform: translateX(100%);
+  }
+  100% {
+    transform: translateX(-100%);
+  }
+`;
+
+const marqueeVerticalAnimation = keyframes`
+  0% {
+    transform: translateY(100%);
+  }
+  100% {
+    transform: translateY(-100%);
+  }
+`;
+
+export const MarqueeItem = styled.div<{
+  vertical: boolean;
+  reverse: boolean;
+  isPaused: boolean;
+}>`
+  display: flex;
+  flex-shrink: 0;
+  justify-content: space-around;
+  gap: var(--gap);
+  ${({ vertical }) => css`
+    animation: ${vertical
+        ? marqueeVerticalAnimation
+        : marqueeHorizontalAnimation}
+      var(--duration) linear infinite;
+  `}
+  animation-direction: ${({ reverse }) => (reverse ? "reverse" : "normal")};
+  animation-play-state: ${({ isPaused }) => (isPaused ? "paused" : "running")};
+`;
+
+export const MarqueeContainer = styled.div<{
+  vertical: boolean;
+  pauseOnHover: boolean;
+  isPaused: boolean;
+  duration: number;
+}>`
+  display: flex;
+  overflow: hidden;
+  padding: 2rem;
+  --duration: ${({ duration }) => `${duration}s`};
+  --gap: 1rem;
+  gap: var(--gap);
+  flex-direction: ${({ vertical }) => (vertical ? "column" : "row")};
+
+  &:hover {
+    .marquee-item {
+      animation-play-state: ${({ pauseOnHover }) =>
+        pauseOnHover ? "paused" : "running"};
+    }
+  }
+`;

--- a/packages/service/src/common/components/Marquee/Marquee.css.ts
+++ b/packages/service/src/common/components/Marquee/Marquee.css.ts
@@ -1,50 +1,46 @@
 import { css, keyframes } from "@emotion/react";
 
-interface MarqueeItemStylesProps {
-  reverse: boolean;
-}
-
-interface MarqueeContainerStylesProps {
+interface MarqueeStylesProps {
   pauseOnHover: boolean;
+  reverse: boolean;
   duration: string;
   gap: string;
 }
 
 const marqueeAnimation = keyframes`
   0% {
-    transform: translateX(100%);
+    transform: translateX(400%);
   }
   100% {
-    transform: translateX(-100%);
+    transform: translateX(-400%);
   }
 `;
 
-export const marqueeItemStyles = ({ reverse }: MarqueeItemStylesProps) => css`
+export const marqueeItemStyles = css`
   display: flex;
   flex-shrink: 0;
   justify-content: space-around;
-  gap: var(--gap);
   animation: ${marqueeAnimation} var(--duration) linear infinite;
-  animation-direction: ${reverse ? "reverse" : "normal"};
+  animation-direction: var(--direction);
   animation-play-state: running;
 `;
 
-export const marqueeContainerStyles = ({
+export const marqueeStyles = ({
   pauseOnHover,
+  reverse,
   duration,
   gap,
-}: MarqueeContainerStylesProps) => css`
+}: MarqueeStylesProps) => css`
   display: flex;
   overflow: hidden;
   padding: 2rem;
+  gap: ${gap};
   --duration: ${duration};
-  --gap: ${gap};
-  gap: var(--gap);
+  --direction: ${reverse ? "reverse" : "normal"};
 
   &:hover {
     ${pauseOnHover &&
-    `
-      div {
+    `div {
         animation-play-state: paused;
       }
     `}

--- a/packages/service/src/common/components/Marquee/Marquee.tsx
+++ b/packages/service/src/common/components/Marquee/Marquee.tsx
@@ -1,22 +1,30 @@
-import { ReactNode } from "react";
-import { marqueeContainerStyles, marqueeItemStyles } from "./Marquee.css";
+import { marqueeStyles, marqueeItemStyles } from "./Marquee.css";
+import { ReactNode, ReactElement, Children } from "react";
+
+interface MarqueeItemProps {
+  children: ReactNode;
+}
+
+const MarqueeItem = ({ children }: MarqueeItemProps) => {
+  return <div css={marqueeItemStyles}>{children}</div>;
+};
 
 interface MarqueeProps {
-  reverse?: boolean;
   pauseOnHover?: boolean;
-  children: ReactNode;
+  reverse?: boolean;
   repeat?: number;
   duration?: number | string; // number로 들어올 경우 s로 포맷팅 됩니다.
   gap?: number | string; // number로 들어올 경우 px로 포맷팅 됩니다.
+  children: Array<ReactElement<typeof MarqueeItem>>;
 }
 
 export const Marquee = ({
-  reverse = false,
   pauseOnHover = false,
-  children,
+  reverse = false,
   repeat = 4,
   duration = "40s",
   gap = "1rem",
+  children,
   ...props
 }: MarqueeProps) => {
   const formattedDuration =
@@ -24,20 +32,23 @@ export const Marquee = ({
 
   const formattedGap = typeof gap === "number" ? `${gap}px` : gap;
 
+  const repeatedChildren = Children.toArray(children).flatMap((child) =>
+    Array(repeat).fill(child),
+  );
+
   return (
     <div
-      css={marqueeContainerStyles({
+      css={marqueeStyles({
         pauseOnHover,
+        reverse,
         duration: formattedDuration,
         gap: formattedGap,
       })}
       {...props}
     >
-      {Array.from({ length: repeat }, (_, i) => (
-        <div css={marqueeItemStyles({ reverse })} key={i}>
-          {children}
-        </div>
-      ))}
+      {repeatedChildren}
     </div>
   );
 };
+
+Marquee.Item = MarqueeItem;

--- a/packages/service/src/common/components/Marquee/Marquee.tsx
+++ b/packages/service/src/common/components/Marquee/Marquee.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useState } from "react";
+import { ReactNode } from "react";
 import { MarqueeContainer, MarqueeItem } from "./Marquee.css";
 
 interface MarqueeProps {
@@ -6,9 +6,9 @@ interface MarqueeProps {
   reverse?: boolean;
   pauseOnHover?: boolean;
   children: ReactNode;
-  vertical?: boolean;
   repeat?: number;
-  duration?: number;
+  duration?: number | string; // number로 들어올 경우 s로 포맷팅 됩니다.
+  gap?: number | string; // number로 들어올 경우 px로 포맷팅 됩니다.
 }
 
 export const Marquee = ({
@@ -16,31 +16,26 @@ export const Marquee = ({
   reverse = false,
   pauseOnHover = false,
   children,
-  vertical = false,
   repeat = 4,
-  duration = 40,
+  duration = "40s",
+  gap = "1rem",
   ...props
 }: MarqueeProps) => {
-  const [isPaused, setIsPaused] = useState(false);
+  const formattedDuration =
+    typeof duration === "number" ? `${duration}s` : duration;
+
+  const formattedGap = typeof gap === "number" ? `${gap}px` : gap;
 
   return (
     <MarqueeContainer
-      vertical={vertical}
       className={className}
       pauseOnHover={pauseOnHover}
-      isPaused={isPaused}
-      duration={duration}
+      duration={formattedDuration}
+      gap={formattedGap}
       {...props}
-      onMouseEnter={() => setIsPaused(true)}
-      onMouseLeave={() => setIsPaused(false)}
     >
       {Array.from({ length: repeat }, (_, i) => (
-        <MarqueeItem
-          key={i}
-          vertical={vertical}
-          reverse={reverse}
-          isPaused={isPaused}
-        >
+        <MarqueeItem key={i} reverse={reverse} className="marquee-item">
           {children}
         </MarqueeItem>
       ))}

--- a/packages/service/src/common/components/Marquee/Marquee.tsx
+++ b/packages/service/src/common/components/Marquee/Marquee.tsx
@@ -35,7 +35,7 @@ export const Marquee = ({
       {...props}
     >
       {Array.from({ length: repeat }, (_, i) => (
-        <MarqueeItem key={i} reverse={reverse} className="marquee-item">
+        <MarqueeItem key={i} reverse={reverse}>
           {children}
         </MarqueeItem>
       ))}

--- a/packages/service/src/common/components/Marquee/Marquee.tsx
+++ b/packages/service/src/common/components/Marquee/Marquee.tsx
@@ -1,8 +1,7 @@
 import { ReactNode } from "react";
-import { MarqueeContainer, MarqueeItem } from "./Marquee.css";
+import { marqueeContainerStyles, marqueeItemStyles } from "./Marquee.css";
 
 interface MarqueeProps {
-  className?: string;
   reverse?: boolean;
   pauseOnHover?: boolean;
   children: ReactNode;
@@ -12,7 +11,6 @@ interface MarqueeProps {
 }
 
 export const Marquee = ({
-  className,
   reverse = false,
   pauseOnHover = false,
   children,
@@ -27,18 +25,19 @@ export const Marquee = ({
   const formattedGap = typeof gap === "number" ? `${gap}px` : gap;
 
   return (
-    <MarqueeContainer
-      className={className}
-      pauseOnHover={pauseOnHover}
-      duration={formattedDuration}
-      gap={formattedGap}
+    <div
+      css={marqueeContainerStyles({
+        pauseOnHover,
+        duration: formattedDuration,
+        gap: formattedGap,
+      })}
       {...props}
     >
       {Array.from({ length: repeat }, (_, i) => (
-        <MarqueeItem key={i} reverse={reverse}>
+        <div css={marqueeItemStyles({ reverse })} key={i}>
           {children}
-        </MarqueeItem>
+        </div>
       ))}
-    </MarqueeContainer>
+    </div>
   );
 };

--- a/packages/service/src/common/components/Marquee/Marquee.tsx
+++ b/packages/service/src/common/components/Marquee/Marquee.tsx
@@ -1,5 +1,6 @@
-import { marqueeStyles, marqueeItemStyles } from "./Marquee.css";
 import { ReactNode, ReactElement, Children } from "react";
+import { marqueeStyles, marqueeItemStyles } from "./Marquee.css";
+import { toPx, toS } from "@service/common/utils/formatter";
 
 interface MarqueeItemProps {
   children: ReactNode;
@@ -27,10 +28,8 @@ const Marquee = ({
   children,
   ...props
 }: MarqueeProps) => {
-  const formattedDuration =
-    typeof duration === "number" ? `${duration}s` : duration;
-
-  const formattedGap = typeof gap === "number" ? `${gap}px` : gap;
+  const formattedDuration = toS(duration);
+  const formattedGap = toPx(gap);
 
   const repeatedChildren = Children.toArray(children).flatMap((child) =>
     Array(repeat).fill(child),

--- a/packages/service/src/common/components/Marquee/Marquee.tsx
+++ b/packages/service/src/common/components/Marquee/Marquee.tsx
@@ -1,0 +1,49 @@
+import { ReactNode, useState } from "react";
+import { MarqueeContainer, MarqueeItem } from "./Marquee.css";
+
+interface MarqueeProps {
+  className?: string;
+  reverse?: boolean;
+  pauseOnHover?: boolean;
+  children: ReactNode;
+  vertical?: boolean;
+  repeat?: number;
+  duration?: number;
+}
+
+export const Marquee = ({
+  className,
+  reverse = false,
+  pauseOnHover = false,
+  children,
+  vertical = false,
+  repeat = 4,
+  duration = 40,
+  ...props
+}: MarqueeProps) => {
+  const [isPaused, setIsPaused] = useState(false);
+
+  return (
+    <MarqueeContainer
+      vertical={vertical}
+      className={className}
+      pauseOnHover={pauseOnHover}
+      isPaused={isPaused}
+      duration={duration}
+      {...props}
+      onMouseEnter={() => setIsPaused(true)}
+      onMouseLeave={() => setIsPaused(false)}
+    >
+      {Array.from({ length: repeat }, (_, i) => (
+        <MarqueeItem
+          key={i}
+          vertical={vertical}
+          reverse={reverse}
+          isPaused={isPaused}
+        >
+          {children}
+        </MarqueeItem>
+      ))}
+    </MarqueeContainer>
+  );
+};

--- a/packages/service/src/common/components/Marquee/Marquee.tsx
+++ b/packages/service/src/common/components/Marquee/Marquee.tsx
@@ -18,7 +18,7 @@ interface MarqueeProps {
   children: Array<ReactElement<typeof MarqueeItem>>;
 }
 
-export const Marquee = ({
+const Marquee = ({
   pauseOnHover = false,
   reverse = false,
   repeat = 4,
@@ -52,3 +52,5 @@ export const Marquee = ({
 };
 
 Marquee.Item = MarqueeItem;
+
+export default Marquee;

--- a/packages/service/src/common/components/Marquee/index.tsx
+++ b/packages/service/src/common/components/Marquee/index.tsx
@@ -1,0 +1,1 @@
+export { Marquee } from "./Marquee";

--- a/packages/service/src/common/components/Marquee/index.tsx
+++ b/packages/service/src/common/components/Marquee/index.tsx
@@ -1,1 +1,2 @@
-export { Marquee } from "./Marquee";
+import Marquee from "./Marquee";
+export { Marquee };

--- a/packages/service/src/common/utils/formatter.ts
+++ b/packages/service/src/common/utils/formatter.ts
@@ -1,0 +1,7 @@
+export function toPx(value: number | string): string {
+  return typeof value === "number" ? `${value}px` : value;
+}
+
+export function toS(value: number | string): string {
+  return typeof value === "number" ? `${value}s` : value;
+}

--- a/packages/service/src/constants/routes.ts
+++ b/packages/service/src/constants/routes.ts
@@ -5,3 +5,4 @@ export const DEMO_PAGE_ROUTE = "/demo" as const;
 export const AUTH_DEMO_PAGE_ROUTE = "auth" as const;
 export const AUTH_CALLBACK_DEMO_PAGE_ROUTE = "auth/callback" as const;
 export const SCROLL_TEXT_DEMO_PAGE_ROUTE = "scroll-text" as const;
+export const MARQUEE_DEMO_PAGE_ROUTE = "marquee" as const;

--- a/packages/service/src/index.css
+++ b/packages/service/src/index.css
@@ -7,5 +7,4 @@
 body,
 body>div {
   height: 100vh;
-  overflow: hidden;
 }

--- a/packages/service/src/router.tsx
+++ b/packages/service/src/router.tsx
@@ -8,12 +8,14 @@ import {
   ROTATE_DEMO_PAGE_ROUTE,
   SCROLL_DEMO_PAGE_ROUTE,
   SCROLL_TEXT_DEMO_PAGE_ROUTE,
+  MARQUEE_DEMO_PAGE_ROUTE,
 } from "./constants/routes";
 import { RotateDemoPage } from "./Demo/pages/RotateDemoPage";
 import { MainPage } from "./Main/pages/MainPage";
 import { AuthDemoPage } from "./Demo/pages/AuthDemoPage";
 import { AssetLoaderContextProvider } from "./common/providers/AssetLoaderContextProvider";
 import { ScrollTextPage } from "./Demo/pages/ScrollTextPage";
+import { MarqueeDemoPage } from "./Demo/pages/MarqueeDemoPage";
 
 export const router = createBrowserRouter([
   {
@@ -46,6 +48,10 @@ export const router = createBrowserRouter([
       {
         path: SCROLL_TEXT_DEMO_PAGE_ROUTE,
         element: <ScrollTextPage />,
+      },
+      {
+        path: MARQUEE_DEMO_PAGE_ROUTE,
+        element: <MarqueeDemoPage />,
       },
     ],
   },


### PR DESCRIPTION
## 연관된 이슈
https://watermelon-clap.atlassian.net/browse/CLAP-58

## 작업 내용
Marquee 컴포넌트 구현
-> 이후 기대평 카드 컴포넌트를 구현 후 해당 Marquee를 통해 움직이는 모션을 나타낼 수 있음

## 리뷰어 멘션
@thgee 

## 스크린샷 (선택)

https://github.com/user-attachments/assets/67fc2fd8-78bd-43c0-b905-3f4c2d7cc6f0

