### PR TITLE
feat(CLAP-82): 메인페이지 기대평 구현

### DIFF
--- a/packages/service/src/common/components/Marquee/Marquee.css.ts
+++ b/packages/service/src/common/components/Marquee/Marquee.css.ts
@@ -9,10 +9,10 @@ interface MarqueeStylesProps {
 
 const marqueeAnimation = keyframes`
   0% {
-    transform: translateX(400%);
+    transform: translateX(100vw);
   }
   100% {
-    transform: translateX(-400%);
+    transform: translateX(-200vw);
   }
 `;
 

--- a/packages/service/src/common/components/Marquee/Marquee.tsx
+++ b/packages/service/src/common/components/Marquee/Marquee.tsx
@@ -24,7 +24,7 @@ const Marquee = ({
   reverse = false,
   repeat = 4,
   duration = "40s",
-  gap = "1rem",
+  gap = "2rem",
   children,
   ...props
 }: MarqueeProps) => {

--- a/packages/service/src/components/main/Expectation/Expectations.tsx
+++ b/packages/service/src/components/main/Expectation/Expectations.tsx
@@ -1,0 +1,28 @@
+import { Marquee } from "@service/common/components/Marquee";
+import * as style from "./style";
+
+export const Expectations = () => {
+  return (
+    <div css={style.container}>
+      <Marquee pauseOnHover>
+        {reviews.map((review) => (
+          <Marquee.Item>
+            <div css={style.expectationCard}>
+              <pre className="text">{review}</pre>
+            </div>
+          </Marquee.Item>
+        ))}
+      </Marquee>
+    </div>
+  );
+};
+
+const reviews = [
+  `강력한 성능과 민첩한 핸들링이라니~
+아반떼 N을 타면 즐거운 드라이빙을 할 수 있을 것 같아요!`,
+  `아반떼 N! 스포티한 자동차를 눈여겨보고 있었는데
+딱 제 취향이에요! 도로에서 자주 보고싶어요~`,
+  `아반떼N 너무 예뻐요! 출시되길 기다리고 있었어요
+일상형 스포츠카 기대 중입니다 ㅎㅎㅎ`,
+  `짧은 기대평`,
+];

--- a/packages/service/src/components/main/Expectation/index.ts
+++ b/packages/service/src/components/main/Expectation/index.ts
@@ -1,0 +1,1 @@
+export * from "./Expectations";

--- a/packages/service/src/components/main/Expectation/style.ts
+++ b/packages/service/src/components/main/Expectation/style.ts
@@ -1,0 +1,53 @@
+import { css } from "@emotion/react";
+import { theme } from "@watermelon-clap/core";
+
+export const container = css`
+  position: relative;
+  display: flex;
+  align-items: center;
+  &::before,
+  &::after {
+    content: "";
+    position: absolute;
+    width: 300px;
+    height: 90px;
+    padding: 40px 0;
+    z-index: 1;
+    top: 0;
+  }
+  &::before {
+    left: 0;
+    background: linear-gradient(to right, black 0%, transparent 100%);
+  }
+
+  &::after {
+    right: 0;
+    background: linear-gradient(to left, black 0%, transparent 100%);
+  }
+`;
+
+export const expectationCard = css`
+  border-radius: 20px;
+  background: ${theme.color.gray100};
+  box-shadow: 0px 0px 20px 0px #fff;
+  padding: 20px 28px;
+  height: 50px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 200px;
+  max-width: 600px;
+  box-sizing: content-box;
+  text-align: center;
+  overflow: hidden;
+
+  &:hover {
+    background: ${theme.color.white};
+    box-shadow: 0px 0px 20px 0px ${theme.color.eventSkyblue};
+  }
+
+  > .text {
+    ${theme.font.pretend.medium.bodyM18}
+    line-height: 1.6rem;
+  }
+`;

--- a/packages/service/src/components/main/index.ts
+++ b/packages/service/src/components/main/index.ts
@@ -1,2 +1,3 @@
 export * from "./Banner";
 export * from "./EventPeriod";
+export * from "./Expectation";

--- a/packages/service/src/pages/Main/Main.tsx
+++ b/packages/service/src/pages/Main/Main.tsx
@@ -1,5 +1,5 @@
 import * as style from "./style";
-import { Banner, EventPeriod } from "@service/components/main";
+import { Banner, EventPeriod, Expectations } from "@service/components/main";
 
 export const Main = () => {
   return (
@@ -7,6 +7,7 @@ export const Main = () => {
       <img src="images/main/main-bg.svg" css={style.mainBg} />
       <Banner />
       <EventPeriod />
+      <Expectations />
     </div>
   );
 };


### PR DESCRIPTION
## 연관된 이슈

- https://watermelon-clap.atlassian.net/browse/CLAP-82

## 작업 내용

- 기대평 카드 구현하고 Marquee 사용하여 메인페이지에 노출
- Marquee 로직 수정 필요함

<img width="800" alt="image" src="https://github.com/user-attachments/assets/50e6eb7e-5923-4dfb-ab66-dc94967e9fe0">

## 리뷰어 멘션

- @DaeWon9 
