### PR TITLE
feat(CLAP-126): 모바일 반응형 미디어쿼리 함수화

### DIFF
--- a/packages/service/src/common/responsive/responsive.ts
+++ b/packages/service/src/common/responsive/responsive.ts
@@ -1,0 +1,10 @@
+import { css, SerializedStyles } from "@emotion/react";
+
+// Galaxy S20 Ultra 기준
+const MOBILE_MAX_WIDTH = "412px" as const;
+
+export const mobile = (styles: SerializedStyles) => css`
+  @media screen and (max-width: ${MOBILE_MAX_WIDTH}) {
+    ${styles}
+  }
+`;


### PR DESCRIPTION
# 🔗 연관된 이슈

- [연관된 이슈 링크](https://watermelon-clap.atlassian.net/browse/CLAP-126?atlOrigin=eyJpIjoiMTQ5MDc2Y2NiOTIyNDdhOGJjYjlhZjk5NDczN2VhNjkiLCJwIjoiaiJ9)
  
<br/>

# 📗 작업 내용

### 이슈 내용
- 반응형 웹을 구현하기로 결정하면서 css 내부에 아래와 같은 보일러플레이트 코드가 발생할 것으로 예상하였습니다.
```
@media screen and (max-width: "412px") {
}
```
- 이를 함수로 만들어두면 코드가 간단해질 것 같아 함수화 하였습니다.  

<br/>

### 변경 사항
- 모바일 뷰의 너비는 Galaxy S20 Ultra 기기의 width인 "412px"을 기준점으로 채택했습니다.
- 미디어쿼리 함수는 아래 예시와 같이 사용할 수 있습니다.

```
예시)

export const bannerContent = css`
  font-size : 28px;

  ${mobile(css`
    font-size: 12px;
  `)} 
`;
```
<br/>


# ✏️ 리뷰어 멘션

- @DaeWon9 
