### PR TITLE
feat(CLAP-85): 이벤트소개 헤더 구현

### DIFF
--- a/packages/service/src/components/nQuizEvent/NQuizTitle/NQuizTitle.css.ts
+++ b/packages/service/src/components/nQuizEvent/NQuizTitle/NQuizTitle.css.ts
@@ -1,0 +1,81 @@
+import { css } from "@emotion/react";
+import { mobile } from "@service/common/responsive/responsive";
+import { theme } from "@watermelon-clap/core";
+
+export const containerStyle = css`
+  ${theme.flex.center};
+  ${theme.flex.column};
+  ${theme.gap.gap48};
+  color: ${theme.color.white};
+
+  ${mobile(css`
+    ${theme.gap.gap24};
+  `)}
+`;
+
+export const logoContainerStyle = css`
+  ${theme.flex.center};
+  ${theme.gap.gap32};
+
+  ${mobile(css`
+    ${theme.gap.gap16};
+  `)}
+`;
+
+export const logoStyle = css`
+  width: 208px;
+  height: 87px;
+
+  ${mobile(css`
+    width: 104px;
+    height: 43px;
+  `)}
+`;
+
+export const titleStyle = css`
+  ${theme.font.pcpB82}
+  color: ${theme.color.white};
+
+  ${mobile(css`
+    font-size: 41px;
+  `)}
+`;
+
+export const dateStyle = css`
+  ${theme.font.pcpL32}
+  color: ${theme.color.eventSkyblue};
+
+  ${mobile(css`
+    font-size: 16px;
+  `)}
+`;
+
+export const contentContainerStyle = css`
+  ${theme.flex.center};
+  ${theme.flex.column};
+  ${theme.gap.gap8};
+
+  ${mobile(css`
+    ${theme.gap.gap4};
+  `)}
+`;
+
+export const contentTextStyle = css`
+  ${theme.font.preB28}
+  color: ${theme.color.white};
+  white-space: nowrap;
+
+  ${mobile(css`
+    font-size: 14px;
+  `)}
+`;
+
+export const hintTextStyle = css`
+  ${theme.font.preB28}
+  color: ${theme.color.eventBlue};
+  white-space: nowrap;
+
+  ${mobile(css`
+    font-size: 14px;
+  `)}
+`;

--- a/packages/service/src/components/nQuizEvent/NQuizTitle/NQuizTitle.tsx
+++ b/packages/service/src/components/nQuizEvent/NQuizTitle/NQuizTitle.tsx
@@ -1,0 +1,32 @@
+import { ReactComponent as NLogo } from "public/images/gnb/n-logo.svg";
+import {
+  containerStyle,
+  logoContainerStyle,
+  logoStyle,
+  titleStyle,
+  dateStyle,
+  contentContainerStyle,
+  contentTextStyle,
+  hintTextStyle,
+} from "./NQuizTitle.css";
+
+export const NQuizTitle = () => {
+  return (
+    <div css={containerStyle}>
+      <div css={logoContainerStyle}>
+        <NLogo css={logoStyle} />
+        <span css={titleStyle}>퀴즈</span>
+      </div>
+      <div css={dateStyle}>2024. 07. 29 ~ 08. 02</div>
+      <div css={contentContainerStyle}>
+        <div css={contentTextStyle}>
+          아반떼 N에 관한 정보를 알아보는 간단한 퀴즈를 맞혀보세요!
+        </div>
+        <div css={contentTextStyle}>매일 선착순 200명에게 경품을 드립니다!</div>
+        <div css={hintTextStyle}>
+          HINT! 상단 바 아반떼 N 페이지에서 정답을 찾을 수 있습니다!
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/service/src/components/nQuizEvent/NQuizTitle/index.ts
+++ b/packages/service/src/components/nQuizEvent/NQuizTitle/index.ts
@@ -1,0 +1,1 @@
+export { NQuizTitle } from "./NQuizTitle";

--- a/packages/service/src/components/nQuizEvent/index.ts
+++ b/packages/service/src/components/nQuizEvent/index.ts
@@ -1,1 +1,2 @@
 export * from "./NQuizSection";
+export * from "./NQuizTitle";


### PR DESCRIPTION
# 🔗 연관된 이슈

- [연관된 이슈 링크](https://watermelon-clap.atlassian.net/browse/CLAP-85?atlOrigin=eyJpIjoiNWEyOGQ1MWJiYTgxNDI5ZGE0MjM4Y2I5NGQxZDZmM2MiLCJwIjoiaiJ9)
  
<br/>

# 📗 작업 내용
이벤트소개 헤더 구현

### 이슈 내용
NQuizEvent 페이지 상단부에 해당 이벤트의 정보를 보여주는 컴포넌트의 필요

### 변경 사항
#### PC View
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/dd44b37c-5092-4fef-bbe5-10a236c07f6e">

#### Mobile View
<img width="380" alt="image" src="https://github.com/user-attachments/assets/a0cc75a5-8b40-416b-a6a9-91cb98162385">

<br/>


# ✏️ 리뷰어 멘션
@thgee 
