### PR TITLE
feat(CLAP-128): 공통 모달 만들기

### DIFF
--- a/packages/service/src/common/components/ModalContainer/AlertModal/AlertModal.css.ts
+++ b/packages/service/src/common/components/ModalContainer/AlertModal/AlertModal.css.ts
@@ -1,0 +1,26 @@
+import { css } from "@emotion/react";
+import { theme } from "@watermelon-clap/core";
+
+export const alertModalStyles = {
+  content: {
+    top: "50%",
+    left: "50%",
+    right: "auto",
+    bottom: "auto",
+    marginRight: "-50%",
+    transform: "translate(-50%, -50%)",
+    borderRadius: "8px",
+    border: "none",
+    boxShadow: "0 2px 10px rgba(0, 0, 0, 0.2)",
+  },
+  overlay: {
+    backgroundColor: "rgba(0, 0, 0, 0.5)",
+  },
+};
+
+export const alertModalBodyStyles = css`
+  ${theme.flex.center}
+  ${theme.flex.column}
+  gap: 48.5px;
+  padding: 23px 46px;
+`;

--- a/packages/service/src/common/components/ModalContainer/AlertModal/AlertModal.tsx
+++ b/packages/service/src/common/components/ModalContainer/AlertModal/AlertModal.tsx
@@ -1,0 +1,38 @@
+import Modal from "react-modal";
+import { Button, ButtonVariant } from "../../Button";
+import { useScrollStop } from "@service/common/hooks/useScrollStop";
+import { alertModalStyles, alertModalBodyStyles } from "./AlertModal.css";
+import { ReactNode } from "react";
+import { DefaultModalProps } from "../ModalContainer";
+
+export interface AlertModalProps extends DefaultModalProps {
+  title: ReactNode;
+  content: ReactNode;
+}
+
+export const AlertModal = ({
+  isOpen,
+  onRequestClose,
+  title,
+  content,
+}: AlertModalProps) => {
+  useScrollStop(isOpen);
+
+  return (
+    <Modal
+      shouldCloseOnEsc
+      isOpen={isOpen}
+      onRequestClose={onRequestClose}
+      style={alertModalStyles}
+      ariaHideApp={false}
+    >
+      <div css={alertModalBodyStyles}>
+        <h2>{title}</h2>
+        <div>{content}</div>
+        <Button variant={ButtonVariant.SHORT} onClick={onRequestClose}>
+          확인
+        </Button>
+      </div>
+    </Modal>
+  );
+};

--- a/packages/service/src/common/components/ModalContainer/AlertModal/index.ts
+++ b/packages/service/src/common/components/ModalContainer/AlertModal/index.ts
@@ -1,0 +1,1 @@
+export * from "./AlertModal";

--- a/packages/service/src/common/components/ModalContainer/GoolgleLoginModal/GoogleLoginModal.tsx
+++ b/packages/service/src/common/components/ModalContainer/GoolgleLoginModal/GoogleLoginModal.tsx
@@ -7,16 +7,12 @@ import {
   googleLoginModalBodyStyles,
 } from "./GoogleLoginModal.css";
 import { theme } from "@watermelon-clap/core";
-
-export interface GoogleLoginModalProps {
-  isOpen: boolean;
-  onRequestClose: () => void;
-}
+import { DefaultModalProps } from "../ModalContainer";
 
 export const GoogleLoginModal = ({
   isOpen,
   onRequestClose,
-}: GoogleLoginModalProps) => {
+}: DefaultModalProps) => {
   const { login } = useAuth();
 
   useScrollStop(isOpen);

--- a/packages/service/src/common/components/ModalContainer/ModalContainer.tsx
+++ b/packages/service/src/common/components/ModalContainer/ModalContainer.tsx
@@ -2,18 +2,24 @@ import { useContext } from "react";
 import { createPortal } from "react-dom";
 import { ModalStateContext } from "@service/common/contexts/ModalContext";
 import { useModal } from "@service/common/hooks/useModal";
-import { GoogleLoginModal, GoogleLoginModalProps } from "./GoolgleLoginModal";
+import { GoogleLoginModal } from "./GoolgleLoginModal";
+import { AlertModal, AlertModalProps } from "./AlertModal";
 
-export type ModalType = "login" | "test";
+export type ModalType = "login" | "alert";
+
+export interface DefaultModalProps {
+  isOpen: boolean;
+  onRequestClose: () => void;
+}
 
 interface ModalComponentMap {
-  login: React.FC<GoogleLoginModalProps>;
-  test: React.FC<GoogleLoginModalProps>;
+  login: React.FC<DefaultModalProps>;
+  alert: React.FC<AlertModalProps>;
 }
 
 const MODAL_COMPONENT_MAP: ModalComponentMap = {
   login: GoogleLoginModal,
-  test: GoogleLoginModal,
+  alert: AlertModal,
 };
 
 export const ModalContainer = () => {


### PR DESCRIPTION
# 🔗 연관된 이슈

- [연관된 이슈 링크](https://watermelon-clap.atlassian.net/browse/CLAP-128)
  
<br/>

# 📗 작업 내용
공통으로 사용 될 AlertModal 구현

### 이슈 내용
서비스 전반적으로 AlertModal이 필요했고
이에, Title, Content를 props로 넘겨받아 보여주는 Modal의 필요성 대두


### 변경 사항
```
export interface AlertModalProps extends DefaultModalProps {
  title: ReactNode;
  content: ReactNode;
}

export const AlertModal = ({
  isOpen,
  onRequestClose,
  title,
  content,
}: AlertModalProps) => {
  useScrollStop(isOpen);

  return (
    <Modal
      shouldCloseOnEsc
      isOpen={isOpen}
      onRequestClose={onRequestClose}
      style={alertModalStyles}
      ariaHideApp={false}
    >
      <div css={alertModalBodyStyles}>
        <h2>{title}</h2>
        <div>{content}</div>
        <Button variant={ButtonVariant.SHORT} onClick={onRequestClose}>
          확인
        </Button>
      </div>
    </Modal>
  );
};
```

### How to use
```
import { useModal } from "@service/common/hooks/useModal";

...

const { openModal } = useModal();
const onClickButton = () => {
  openModal({ type: "alert", props: { title: "TEST", content: "CONTENT" } });
};

return (
  <div>
    <Button onClick={onClickButton}>Click Me !</Button>
  </div>
);

```

https://github.com/user-attachments/assets/62ffe13a-36b5-48d2-ab15-d0c6f7c40fc2



# ✏️ 리뷰어 멘션
@thgee 
