### PR TITLE
chore(CLAP-129): 모바일뷰 분기점 변경 `412px -> 768px`

### DIFF
--- a/packages/service/src/constants/breakpoints.ts
+++ b/packages/service/src/constants/breakpoints.ts
@@ -1,3 +1,2 @@
-// Galaxy S20 Ultra 기준
-export const MOBILE_BREAKPOINT = "412px" as const;
+export const MOBILE_BREAKPOINT = "768px" as const;
 export const GNB_BREAKPOINT = "800px" as const;


### PR DESCRIPTION
# 🔗 연관된 이슈

- [연관된 이슈 링크](https://watermelon-clap.atlassian.net/browse/CLAP-129?atlOrigin=eyJpIjoiZDIzMWVjN2M3NzYyNDBkMWI4MDFhNjNiY2I2NjQ5ZDkiLCJwIjoiaiJ9)
  
<br/>

# 📗 작업 내용

### 이슈 내용
- 크기가 큰 디바이스에서도 반응형 뷰가 적용되어야 함


### 변경 사항
- 모바일뷰 분기점 `412px -> 768px` 으로 변경

<br/>


# ✏️ 리뷰어 멘션

- @DaeWon9 
