### PR TITLE
chore: NewCarInfo 내부의 useElementViewportPosition 을 hooks 폴더로 분리

### DIFF
--- a/packages/service/src/common/hooks/useElementViewportPosition.ts
+++ b/packages/service/src/common/hooks/useElementViewportPosition.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from "react";
+
+export const useElementViewportPosition = (
+  ref: React.RefObject<HTMLElement>,
+) => {
+  const [position, setPosition] = useState<[number, number]>([0, 0]);
+
+  useEffect(() => {
+    if (!ref || !ref.current) return;
+
+    const pageHeight = document.body.scrollHeight;
+    const start = ref.current.offsetTop;
+    const end = start + ref.current.offsetHeight;
+
+    setPosition([start / pageHeight, end / pageHeight]);
+  }, []);
+
+  return { position };
+};

--- a/packages/service/src/components/newCar/NewCarInfo/NewCarInfo.tsx
+++ b/packages/service/src/components/newCar/NewCarInfo/NewCarInfo.tsx
@@ -5,22 +5,7 @@ import { useEffect, useRef, useState } from "react";
 import { useMobile } from "@service/common/hooks/useMobile";
 import { Space } from "@service/common/styles/Space";
 import { css } from "@emotion/react";
-
-const useElementViewportPosition = (ref: React.RefObject<HTMLElement>) => {
-  const [position, setPosition] = useState<[number, number]>([0, 0]);
-
-  useEffect(() => {
-    if (!ref || !ref.current) return;
-
-    const pageHeight = document.body.scrollHeight;
-    const start = ref.current.offsetTop;
-    const end = start + ref.current.offsetHeight;
-
-    setPosition([start / pageHeight, end / pageHeight]);
-  }, []);
-
-  return { position };
-};
+import { useElementViewportPosition } from "@service/common/hooks/useElementViewportPosition";
 
 export const NewCarInfo = () => {
   const ref = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
# 🔗 연관된 이슈

- [연관된 이슈 링크](https://github.com/softeerbootcamp4th/Team5-WatermelonClap-FE/pull/56#discussion_r1706302783)
  
<br/>

# 📗 작업 내용

- 피드백 내용 반영
- NewCarInfo 내부의 useElementViewportPosition 을 hooks 폴더로 분리


# ✏️ 리뷰어 멘션

- @DaeWon9 
