### PR TITLE
hotfix: 신차소개 페이지 배경에 원 이미지가 레이어 앞쪽에 돌출되던 이슈 해결

### DIFF
--- a/packages/service/public/images/common/bg-circle-blue.svg
+++ b/packages/service/public/images/common/bg-circle-blue.svg
@@ -1,5 +1,5 @@
 <svg width="1402" height="1402" viewBox="0 0 1402 1402" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g opacity="0.22" filter="url(#filter0_f_2444_2369)">
+<g opacity="0.14" filter="url(#filter0_f_2444_2369)">
 <circle cx="701" cy="701" r="401" fill="#6D5DFF"/>
 </g>
 <defs>

--- a/packages/service/public/images/common/bg-circle-green.svg
+++ b/packages/service/public/images/common/bg-circle-green.svg
@@ -1,5 +1,5 @@
 <svg width="967" height="967" viewBox="0 0 967 967" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g opacity="0.22" filter="url(#filter0_f_2444_2370)">
+<g opacity="0.18" filter="url(#filter0_f_2444_2370)">
 <circle cx="483.5" cy="483.5" r="183.5" fill="#B0FF61"/>
 </g>
 <defs>

--- a/packages/service/src/components/newCar/NewCarInfo/NewCarInfo.css.ts
+++ b/packages/service/src/components/newCar/NewCarInfo/NewCarInfo.css.ts
@@ -42,13 +42,13 @@ export const m_infoImg = (num: number) => css`
 
 export const bgCirlce1 = css`
   position: absolute;
-  top: -100px;
+  top: 0px;
   left: -200px;
   width: calc(300px + 36vw);
 `;
 export const bgCirlce2 = css`
   position: absolute;
-  top: 200px;
-  right: -200px;
+  top: -200px;
+  right: -250px;
   width: calc(400px + 40vw);
 `;

--- a/packages/service/src/components/newCar/NewCarInfo/NewCarInfo.tsx
+++ b/packages/service/src/components/newCar/NewCarInfo/NewCarInfo.tsx
@@ -69,6 +69,8 @@ export const NewCarInfo = () => {
   return (
     <section ref={ref} css={style.scrollContainer}>
       <div css={style.stickyWrap}>
+        <img css={style.bgCirlce1} src="/images/common/bg-circle-green.svg" />
+        <img css={style.bgCirlce2} src="/images/common/bg-circle-blue.svg" />
         <motion.div css={style.imgWrap} ref={carouselRef} style={{ x }}>
           <div
             css={css`
@@ -88,9 +90,6 @@ export const NewCarInfo = () => {
             />
           ))}
         </motion.div>
-
-        <img css={style.bgCirlce1} src="/images/newCar/bg-circle-1.svg" />
-        <img css={style.bgCirlce2} src="/images/newCar/bg-circle-2.svg" />
       </div>
     </section>
   );


### PR DESCRIPTION

# 📗 작업 내용

- 신차소개 페이지 배경에 원 이미지가 레이어 앞쪽에 돌출되던 이슈 해결
- 코드 순서를 교체하여 해결함
- 이미지 위치도 적절히 수정함

<br/>


# ✏️ 리뷰어 멘션

- @DaeWon9 
