### PR TITLE
hotfix: 모바일 뷰 깨짐 현상 수정

### DIFF
--- a/packages/service/src/common/components/Button/Button.tsx
+++ b/packages/service/src/common/components/Button/Button.tsx
@@ -10,9 +10,9 @@ import {
 } from "./Button.css";
 import { mobile } from "@service/common/responsive/responsive";
 
-interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: ButtonVariant;
-  onClick?: () => void;
+  onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
 const getButtonVariantStyles = (variant: ButtonVariant) => {
@@ -49,7 +49,7 @@ const getButtonVariantStyles = (variant: ButtonVariant) => {
   return [commonStyle, eachStyle];
 };
 
-const Button = ({
+export const Button = ({
   variant = ButtonVariant.SHORT,
   onClick = () => {},
   ...props
@@ -62,5 +62,3 @@ const Button = ({
     />
   );
 };
-
-export default Button;

--- a/packages/service/src/common/components/Button/index.ts
+++ b/packages/service/src/common/components/Button/index.ts
@@ -1,3 +1,2 @@
-import Button from "./Button";
-import { ButtonVariant } from "./type";
-export { Button, ButtonVariant };
+export * from "./Button";
+export { ButtonVariant } from "./type";

--- a/packages/service/src/common/components/Footer/Footer.css.ts
+++ b/packages/service/src/common/components/Footer/Footer.css.ts
@@ -9,19 +9,17 @@ export const footerStyles = css`
   background-color: #1c1b1b;
   ${theme.font.preM14}
   color: ${theme.color.white};
+
   ${mobile(css`
     padding: 20px 20px;
   `)}
 
   .inner-wrap {
     width: 100%;
-    min-width: 800px;
-    max-width: 1120px;
     margin: 0 auto;
 
     ${mobile(css`
       min-width: 100px;
-      max-width: 1000px;
     `)}
   }
 

--- a/packages/service/src/common/components/Footer/Footer.css.ts
+++ b/packages/service/src/common/components/Footer/Footer.css.ts
@@ -9,9 +9,7 @@ export const footerStyles = css`
   background-color: #1c1b1b;
   ${theme.font.preM14}
   color: ${theme.color.white};
-  min-width: 1200px;
   ${mobile(css`
-    min-width: 412px;
     padding: 20px 20px;
   `)}
 
@@ -22,8 +20,8 @@ export const footerStyles = css`
     margin: 0 auto;
 
     ${mobile(css`
-      min-width: 380px;
-      max-width: 380px;
+      min-width: 100px;
+      max-width: 1000px;
     `)}
   }
 

--- a/packages/service/src/common/components/GlobalNavigationBar/GlobalNavs/GlobalNavs.tsx
+++ b/packages/service/src/common/components/GlobalNavigationBar/GlobalNavs/GlobalNavs.tsx
@@ -4,6 +4,7 @@ import { linkStyles, navsContainerStyles, nLogoStyles } from "./GlobalNavs.css";
 import {
   NEW_CAR_PAGE_ROUTE,
   PICK_EVENT_PAGE_ROUTE,
+  N_QUIZ_EVENT_PAGE_ROUTE,
 } from "@service/constants/routes";
 
 const GlobalNavs = ({ isOpen }: { isOpen: boolean }) => {
@@ -15,7 +16,7 @@ const GlobalNavs = ({ isOpen }: { isOpen: boolean }) => {
       <Link to={PICK_EVENT_PAGE_ROUTE} css={linkStyles}>
         내 아반떼 N 뽑기
       </Link>
-      <Link to="#" css={linkStyles}>
+      <Link to={N_QUIZ_EVENT_PAGE_ROUTE} css={linkStyles}>
         <NLogo css={nLogoStyles} /> 퀴즈
       </Link>
       <Link to="#" css={linkStyles}>

--- a/packages/service/src/common/components/ModalContainer/AlertModal/AlertModal.css.ts
+++ b/packages/service/src/common/components/ModalContainer/AlertModal/AlertModal.css.ts
@@ -1,4 +1,5 @@
 import { css } from "@emotion/react";
+import { mobile } from "@service/common/responsive/responsive";
 import { theme } from "@watermelon-clap/core";
 
 export const alertModalStyles = {
@@ -23,4 +24,9 @@ export const alertModalBodyStyles = css`
   ${theme.flex.column}
   gap: 48.5px;
   padding: 23px 46px;
+
+  ${mobile(css`
+    gap: 30px;
+    padding: 12px 23px;
+  `)}
 `;

--- a/packages/service/src/components/nQuizEvent/NQuizSection/NQuizSection.css.ts
+++ b/packages/service/src/components/nQuizEvent/NQuizSection/NQuizSection.css.ts
@@ -8,14 +8,12 @@ export const nQuizSectionStyles = css`
   ${theme.flex.column}
   width: 100%;
   aspect-ratio: 1.37 / 1;
-  min-width: 800px;
   flex-shrink: 0;
   border-radius: 20px;
   background-color: ${theme.color.white};
   padding: 40px 48px;
 
   ${mobile(css`
-    min-width: 350px;
     padding: 20px 21px;
     border-radius: 10px;
   `)}

--- a/packages/service/src/constants/routes.ts
+++ b/packages/service/src/constants/routes.ts
@@ -10,5 +10,5 @@ export const BUTTON_DEMO_PAGE_ROUTE = "button" as const;
 export const MODAL_DEMO_PAGE_ROUTE = "modal" as const;
 export const N_QUIZ_EVENT_PAGE_ROUTE = "/quiz-event" as const;
 export const NEW_CAR_PAGE_ROUTE = "/new-car" as const;
-export const N_CARD_PICK_PAGE_ROUTE = "/card-pick" as const;
+export const N_PARTS_PICK_PAGE_ROUTE = "/parts-pick" as const;
 export const PICK_EVENT_PAGE_ROUTE = "/pick-event" as const;

--- a/packages/service/src/pages/NQuizEvent/NQuizEvent.tsx
+++ b/packages/service/src/pages/NQuizEvent/NQuizEvent.tsx
@@ -5,7 +5,6 @@ import {
   NQuizRewardProps,
 } from "@service/components/nQuizEvent";
 import {
-  containerStyle,
   backgroundStyle,
   gridStyle,
   termTitleStyle,
@@ -48,7 +47,7 @@ const rewardList: NQuizRewardProps[] = [
 
 export const NQuizEvent = () => {
   return (
-    <div css={containerStyle}>
+    <>
       <div css={backgroundStyle}>
         <NQuizTitle />
 
@@ -77,6 +76,6 @@ export const NQuizEvent = () => {
           ))}
         </ul>
       </div>
-    </div>
+    </>
   );
 };

--- a/packages/service/src/pages/PartsPick/PartsPick.tsx
+++ b/packages/service/src/pages/PartsPick/PartsPick.tsx
@@ -1,9 +1,4 @@
 import { Button, ButtonVariant } from "@service/common/components/Button";
-// import {
-//   backgroundStyle,
-//   buttonStyle,
-//   modalContentStyle,
-// } from "./PartsPick.css";
 import {
   partsPickBackgroundStyle,
   partsPickButtonStyle,

--- a/packages/service/src/router.tsx
+++ b/packages/service/src/router.tsx
@@ -12,7 +12,7 @@ import {
   N_QUIZ_EVENT_PAGE_ROUTE,
   NEW_CAR_PAGE_ROUTE,
   PICK_EVENT_PAGE_ROUTE,
-  N_CARD_PICK_PAGE_ROUTE,
+  N_PARTS_PICK_PAGE_ROUTE,
 } from "./constants/routes";
 import { RotateDemoPage } from "./Demo/pages/RotateDemoPage";
 import { AuthDemoPage } from "./Demo/pages/AuthDemoPage";
@@ -38,7 +38,7 @@ export const router = createBrowserRouter([
       { path: N_QUIZ_EVENT_PAGE_ROUTE, element: <NQuizEvent /> },
       { path: PICK_EVENT_PAGE_ROUTE, element: <PickEvent /> },
       { path: NEW_CAR_PAGE_ROUTE, element: <NewCar /> },
-      { path: N_CARD_PICK_PAGE_ROUTE, element: <PartsPick /> },
+      { path: N_PARTS_PICK_PAGE_ROUTE, element: <PartsPick /> },
     ],
   },
   {


### PR DESCRIPTION
# 🔗 연관된 이슈

- [연관된 이슈 링크](https://watermelon-clap.atlassian.net/browse/CLAP-131)
  
<br/>

# 📗 작업 내용

- Footer가 삐져나오는 현상 수정
- 모바일 뷰에서 alertModal 패딩수정
- 선착순 퀴즈 페이지 모바일 뷰 수정

<br/>


# ✏️ 리뷰어 멘션
@thgee 
