### PR TITLE
hotfix: 모바일 뷰 오류 수정

### DIFF
--- a/packages/service/src/components/newCar/NewCarInfo/NewCarInfo.css.ts
+++ b/packages/service/src/components/newCar/NewCarInfo/NewCarInfo.css.ts
@@ -21,7 +21,7 @@ export const stickyWrap = css`
 
 export const infoImg = css`
   height: calc(300px + 10vw);
-  z-index: 999;
+  z-index: 3;
 `;
 
 export const imgWrap = css`
@@ -36,7 +36,7 @@ export const m_imgWrap = css`
 `;
 
 export const m_infoImg = (num: number) => css`
-  z-index: 999;
+  z-index: 3;
   width: 80%;
   align-self: ${num === 0 ? "start" : "end"};
 

--- a/packages/service/src/pages/NQuizEvent/NQuizEvent.css.ts
+++ b/packages/service/src/pages/NQuizEvent/NQuizEvent.css.ts
@@ -21,7 +21,7 @@ export const backgroundStyle = css`
   padding-bottom: 94px;
 
   ${mobile(css`
-    min-width: 412px;
+    min-width: 0px;
     padding: 20vw 6vw;
     padding-bottom: 47px;
   `)}


### PR DESCRIPTION

# 📗 작업 내용
- 신차소개 페이지 모바일뷰에서 infoImg 가 상단부로 올라갈 때, GNB와 z-index가 같아 GNB위로 올라오는 이슈 수정
- NQuiz 이벤트 페이지에서 min-width가 412로 표기되어있어 해당 사이즈보다 작은 뷰에서 여백이 보이는 이슈 수정

### 변경 사항
- 신차소개 페이지  infoImg 의 z-idex 수정 999 -> 3
- NQuizEvent.css.ts 내부의 backgroundStyle - mobile 내부의 min-width = 0px 으로 변경

<br/>


# ✏️ 리뷰어 멘션
@thgee 
