### PR TITLE
chore(CLAP-132): 퀴즈페이지 모바일 뷰 수정

### DIFF
--- a/packages/service/src/components/nQuizEvent/NQuizReward/NQuizReward.css.ts
+++ b/packages/service/src/components/nQuizEvent/NQuizReward/NQuizReward.css.ts
@@ -14,6 +14,7 @@ export const containerStyle = (status: eventStatusType) => css`
 
   ${mobile(css`
     gap: 6px;
+    width: 26vw;
   `)};
 `;
 
@@ -23,7 +24,7 @@ export const dateStyle = (status: eventStatusType) => css`
   ${status === "upcoming" && "opacity: 0.6;"}
 
   ${mobile(css`
-    font-size: 10px;
+    font-size: 14px;
   `)}
 `;
 
@@ -54,26 +55,26 @@ export const imgStyle = css`
 
 export const nameStyle = css`
   ${theme.font.preB16}
+  text-align: center;
   font-size: 12px;
-  white-space: nowrap;
   color: black;
   padding-top: 7%;
   padding-bottom: 7%;
+  word-break: keep-all;
 
   ${mobile(css`
-    font-size: 4px;
+    font-size: 10px;
   `)}
 `;
 
 export const openExpectedDateStyle = (status: eventStatusType) => css`
   ${theme.font.preB16}
-  white-space: nowrap;
 
   ${status === "upcoming" && "opacity: 0.6;"}
   ${status !== "upcoming" && "visibility: hidden;"}
 
   ${mobile(css`
-    font-size: 6px;
+    font-size: 8px;
   `)}
 `;
 
@@ -86,6 +87,6 @@ export const endTextStyle = (status: eventStatusType) => css`
   ${(status === "open" || status === "upcoming") && "visibility: hidden;"}
 
   ${mobile(css`
-    font-size: 12px;
+    font-size: 18px;
   `)}
 `;

--- a/packages/service/src/components/nQuizEvent/NQuizTitle/NQuizTitle.css.ts
+++ b/packages/service/src/components/nQuizEvent/NQuizTitle/NQuizTitle.css.ts
@@ -65,7 +65,7 @@ export const contentContainerStyle = css`
 export const contentTextStyle = css`
   ${theme.font.preB28}
   color: ${theme.color.white};
-  white-space: nowrap;
+  text-align: center;
 
   ${mobile(css`
     font-size: 14px;
@@ -75,7 +75,7 @@ export const contentTextStyle = css`
 export const hintTextStyle = css`
   ${theme.font.preB28}
   color: ${theme.color.eventBlue};
-  white-space: nowrap;
+  text-align: center;
 
   ${mobile(css`
     font-size: 14px;

--- a/packages/service/src/pages/NQuizEvent/NQuizEvent.css.ts
+++ b/packages/service/src/pages/NQuizEvent/NQuizEvent.css.ts
@@ -27,7 +27,7 @@ export const backgroundStyle = css`
   `)}
 `;
 
-export const gridStyle = css`
+export const rewardWrapStyle = css`
   display: grid;
   grid-template-columns: repeat(5, 1fr);
   width: 100%;

--- a/packages/service/src/pages/NQuizEvent/NQuizEvent.css.ts
+++ b/packages/service/src/pages/NQuizEvent/NQuizEvent.css.ts
@@ -36,7 +36,11 @@ export const gridStyle = css`
   gap: 16px;
 
   ${mobile(css`
-    min-width: 350px;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    min-width: 0px;
     margin: 41px 0;
     gap: 8px;
   `)}

--- a/packages/service/src/pages/NQuizEvent/NQuizEvent.tsx
+++ b/packages/service/src/pages/NQuizEvent/NQuizEvent.tsx
@@ -6,7 +6,7 @@ import {
 } from "@service/components/nQuizEvent";
 import {
   backgroundStyle,
-  gridStyle,
+  rewardWrapStyle,
   termTitleStyle,
   termListStyle,
 } from "./NQuizEvent.css";
@@ -51,7 +51,7 @@ export const NQuizEvent = () => {
       <div css={backgroundStyle}>
         <NQuizTitle />
 
-        <div css={gridStyle}>
+        <div css={rewardWrapStyle}>
           {rewardList.map((reward, index) => (
             <NQuizReward
               key={index}


### PR DESCRIPTION
# 🔗 연관된 이슈

- [연관된 이슈 링크](https://watermelon-clap.atlassian.net/browse/CLAP-132?atlOrigin=eyJpIjoiMzk1NTYxODk1NzA2NDZkYmJkMDI2MDA1YjM0MzE3ZDUiLCJwIjoiaiJ9)
  
<br/>

# 📗 작업 내용

### 이슈 내용
모바일뷰에서 Reward 컴포넌트가 잘 안보이는 이슈


### 변경 사항
#### < 전 >
<img width="251" alt="image" src="https://github.com/user-attachments/assets/cc9b2d9d-388e-4e0f-b51a-9dd6189465ab">


#### < 후 >
<img width="250" alt="image" src="https://github.com/user-attachments/assets/4e79c7c9-59a2-4f43-9be7-c18698bb1518">


<br/>


# ✏️ 리뷰어 멘션

@thgee 
