### PR TITLE
feat(CLAP-67): 당첨자 정보 입력 폼 만들기

### DIFF
--- a/packages/core/src/types/orderEvent/index.ts
+++ b/packages/core/src/types/orderEvent/index.ts
@@ -30,5 +30,5 @@ export interface IPostOrderEventRequest {
 
 export interface IPostOrderEventResponse {
   result: OrderEventResultType;
-  ApplyTicket?: string;
+  applyTicket?: string;
 }

--- a/packages/service/src/apis/orderEvent/apiPostOrderEventApply.ts
+++ b/packages/service/src/apis/orderEvent/apiPostOrderEventApply.ts
@@ -1,0 +1,27 @@
+import { customFetch } from "@watermelon-clap/core/src/utils";
+import { IPostOrderEventApplyRequest } from "./type";
+
+export const apiPostOrderEventApply = async ({
+  eventId,
+  quizId,
+  phoneNumber,
+  appplyTicket,
+}: IPostOrderEventApplyRequest): Promise<Response> => {
+  return customFetch(
+    `${import.meta.env.VITE_BACK_BASE_URL}/event/order/${eventId}/${quizId}/apply`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ApplyTicket: appplyTicket,
+      },
+      body: JSON.stringify({ phoneNumber: phoneNumber }),
+    },
+  )
+    .then((response) => {
+      return response;
+    })
+    .catch((error) => {
+      throw error;
+    });
+};

--- a/packages/service/src/apis/orderEvent/type.ts
+++ b/packages/service/src/apis/orderEvent/type.ts
@@ -1,0 +1,6 @@
+export interface IPostOrderEventApplyRequest {
+  eventId: string;
+  quizId: string;
+  phoneNumber: string;
+  appplyTicket: string;
+}

--- a/packages/service/src/common/components/ModalContainer/content/modalContent.tsx
+++ b/packages/service/src/common/components/ModalContainer/content/modalContent.tsx
@@ -40,3 +40,10 @@ export const MODAL_CONTENT_QUIZ_WRONG = (
     <p>아반떼 N 페이지에서 정답을 확인해 주세요.</p>
   </div>
 );
+
+export const MODAL_CONTENT_ORDER_EVENT_APPLY_SUCCESS = (
+  <div css={[theme.flex.center, theme.flex.column]}>
+    <p>신청되었습니다.</p>
+    <p>경품은 추후 문자를 통해 발송됩니다.</p>
+  </div>
+);

--- a/packages/service/src/common/utils/formatter.ts
+++ b/packages/service/src/common/utils/formatter.ts
@@ -5,3 +5,13 @@ export function toPx(value: number | string): string {
 export function toS(value: number | string): string {
   return typeof value === "number" ? `${value}s` : value;
 }
+
+export const phoneNumberAutoFormat = (phoneNumber: string): string => {
+  const number = phoneNumber.trim().replace(/[^0-9]/g, "");
+
+  if (number.length < 4) return number;
+  if (number.length < 7) return number.replace(/(\d{3})(\d{1})/, "$1-$2");
+  if (number.length < 11)
+    return number.replace(/(\d{3})(\d{3})(\d{1})/, "$1-$2-$3");
+  return number.replace(/(\d{3})(\d{4})(\d{4})/, "$1-$2-$3");
+};

--- a/packages/service/src/components/nQuizEvent/NQuizSection/NQuizInput/NQuizInput.tsx
+++ b/packages/service/src/components/nQuizEvent/NQuizSection/NQuizInput/NQuizInput.tsx
@@ -15,6 +15,8 @@ import {
   MODAL_N_QUIZ_TITLE,
 } from "@service/common/components/ModalContainer/content/modalContent";
 import { useErrorBoundary } from "react-error-boundary";
+import { useNavigate } from "react-router-dom";
+import { N_QUIZ_EVENT_PAGE_WINNER_APLLY_PAGE_ROUTE } from "@service/constants/routes";
 
 interface NQuizInputProps {
   openedQuiz: IOrderEvent;
@@ -24,6 +26,7 @@ export const NQuizInput = ({ openedQuiz }: NQuizInputProps) => {
   const [inputValue, setInputValue] = useState<string>("");
   const { showBoundary } = useErrorBoundary();
   const { closeModal, openModal } = useModal();
+  const navigate = useNavigate();
 
   const handleSubmit = () => {
     if (inputValue.trim() === "") return;
@@ -46,32 +49,14 @@ export const NQuizInput = ({ openedQuiz }: NQuizInputProps) => {
   const handleApiResponse = (response: IPostOrderEventResponse) => {
     switch (response.result) {
       case "SUCCESS":
-        craftSideCannons(2);
-        openModal({
-          type: "alert",
-          props: {
-            title: MODAL_N_QUIZ_TITLE,
-            content: "정답!! 너 재능있어~",
-          },
-        });
+        handleSuccessResponse(response.applyTicket as string);
         break;
       case "WRONG":
-        openModal({
-          type: "navigate",
-          props: {
-            title: MODAL_N_QUIZ_TITLE,
-            content: MODAL_CONTENT_QUIZ_WRONG,
-          },
-        });
+        handleWrongResponse();
         break;
       case "CLOSED":
-        openModal({
-          type: "alert",
-          props: {
-            title: MODAL_N_QUIZ_TITLE,
-            content: MODAL_CONTENT_QUIZ_CLOSED,
-          },
-        });
+        handleClosedResponse();
+        break;
     }
   };
 
@@ -88,6 +73,33 @@ export const NQuizInput = ({ openedQuiz }: NQuizInputProps) => {
     if (event.key === "Enter") {
       handleSubmit();
     }
+  };
+
+  const handleSuccessResponse = (applyTicket: string) => {
+    localStorage.setItem("ApplyTicket", applyTicket);
+    closeModal();
+    navigate(N_QUIZ_EVENT_PAGE_WINNER_APLLY_PAGE_ROUTE);
+    craftSideCannons(2);
+  };
+
+  const handleWrongResponse = () => {
+    openModal({
+      type: "navigate",
+      props: {
+        title: MODAL_N_QUIZ_TITLE,
+        content: MODAL_CONTENT_QUIZ_WRONG,
+      },
+    });
+  };
+
+  const handleClosedResponse = () => {
+    openModal({
+      type: "alert",
+      props: {
+        title: MODAL_N_QUIZ_TITLE,
+        content: MODAL_CONTENT_QUIZ_CLOSED,
+      },
+    });
   };
 
   return (

--- a/packages/service/src/constants/routes.ts
+++ b/packages/service/src/constants/routes.ts
@@ -13,3 +13,5 @@ export const NEW_CAR_PAGE_ROUTE = "/new-car" as const;
 export const N_PARTS_PICK_PAGE_ROUTE = "/parts-pick" as const;
 export const PICK_EVENT_PAGE_ROUTE = "/pick-event" as const;
 export const PARTS_COLLECTION_PAGE_ROUTE = "/parts-collection" as const;
+export const N_QUIZ_EVENT_PAGE_WINNER_APLLY_PAGE_ROUTE =
+  "/quiz-event-apply" as const;

--- a/packages/service/src/pages/NQuizEventWinnerApply/NQuizEventWinnerApply.css.ts
+++ b/packages/service/src/pages/NQuizEventWinnerApply/NQuizEventWinnerApply.css.ts
@@ -1,0 +1,134 @@
+import { css } from "@emotion/react";
+import { mobile } from "@service/common/responsive/responsive";
+import { theme } from "@watermelon-clap/core/src/theme";
+
+export const backgroundStyle = css`
+  background-image: url("/images/quiz/nQuizBackground.png");
+  background-size: cover;
+  background-position: top;
+  background-repeat: no-repeat;
+  width: 100%;
+
+  ${theme.flex.center}
+  ${theme.flex.column}
+
+  padding: 100px 18vw;
+  padding-bottom: 94px;
+
+  gap: 20px;
+
+  ${mobile(css`
+    min-width: 0px;
+    padding: 20vw 6vw;
+    padding-bottom: 47px;
+  `)};
+`;
+
+export const logoContainerStyle = css`
+  ${theme.flex.center};
+  ${theme.gap.gap32};
+
+  ${mobile(css`
+    ${theme.gap.gap16};
+  `)}
+`;
+
+export const logoStyle = css`
+  width: 208px;
+  height: 87px;
+  text-shadow: 0 0 40px rgba(255, 255, 255, 0.6);
+
+  ${mobile(css`
+    width: 104px;
+    height: 43px;
+  `)}
+`;
+
+export const titleStyle = css`
+  ${theme.font.pcpB82}
+  color: ${theme.color.white};
+  text-shadow: 0 0 40px rgba(255, 255, 255, 0.6);
+
+  ${mobile(css`
+    font-size: 41px;
+  `)};
+`;
+
+export const contentContainerStyle = css`
+  ${theme.flex.center};
+  ${theme.flex.column};
+  ${theme.gap.gap8};
+
+  ${mobile(css`
+    ${theme.gap.gap4};
+  `)}
+`;
+
+export const cheersTextStyle = css`
+  ${theme.font.preB38}
+  color: ${theme.color.eventBlue};
+  text-align: center;
+
+  ${mobile(css`
+    font-size: 14px;
+  `)}
+`;
+
+export const contentTextStyle = css`
+  ${theme.font.preB24}
+  color: ${theme.color.white};
+  text-align: center;
+
+  ${mobile(css`
+    font-size: 14px;
+  `)}
+`;
+
+export const inputContainerStyle = css`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const inputStyle = css`
+  display: flex;
+  width: 566px;
+  height: 52px;
+  padding: 15px 18px;
+  align-items: center;
+  gap: 10px;
+  align-self: stretch;
+  border-radius: 8px;
+  background: var(--Gray-100, #ececec);
+`;
+
+export const listStyle = css`
+  width: 566px;
+  display: flex;
+  flex-direction: column;
+  color: ${theme.color.gray300};
+  align-items: start;
+  gap: 10px;
+`;
+
+export const listItemStyle = css`
+  ${theme.font.preM18}
+  color: ${theme.color.gray300};
+  margin-left: 22px;
+`;
+
+export const rewardContainerStyle = css`
+  width: 200px;
+  height: 300px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const centeredContainerStyle = css`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;

--- a/packages/service/src/pages/NQuizEventWinnerApply/NQuizEventWinnerApply.tsx
+++ b/packages/service/src/pages/NQuizEventWinnerApply/NQuizEventWinnerApply.tsx
@@ -1,0 +1,143 @@
+import { ChangeEvent, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { apiGetOrderEvent } from "@service/apis/orderEvent";
+import { apiPostOrderEventApply } from "@service/apis/orderEvent/apiPostOrderEventApply";
+import { phoneNumberAutoFormat } from "@service/common/utils";
+import { IOrderEvent } from "@watermelon-clap/core/src/types";
+import { NQuizReward } from "@service/components/nQuizEvent";
+import { ReactComponent as NLogo } from "public/images/gnb/n-logo.svg";
+import { CheckBox } from "@service/common/components/CheckBox";
+import { Button } from "@service/common/components/Button";
+import { MAIN_PAGE_ROUTE } from "@service/constants/routes";
+import {
+  backgroundStyle,
+  logoContainerStyle,
+  logoStyle,
+  titleStyle,
+  contentContainerStyle,
+  cheersTextStyle,
+  contentTextStyle,
+  inputContainerStyle,
+  inputStyle,
+  listStyle,
+  listItemStyle,
+  rewardContainerStyle,
+  centeredContainerStyle,
+} from "./NQuizEventWinnerApply.css";
+import { useModal } from "@watermelon-clap/core/src/hooks";
+import {
+  MODAL_CONTENT_ORDER_EVENT_APPLY_SUCCESS,
+  MODAL_N_QUIZ_TITLE,
+} from "@service/common/components/ModalContainer/content/modalContent";
+
+export const NQuizEventWinnerApply = () => {
+  const [isChecked, setIsChecked] = useState<boolean>(false);
+  const [phoneNumber, setPhoneNumber] = useState<string>("");
+  const { openModal } = useModal();
+  const navigate = useNavigate();
+
+  const { data: quizList } = useSuspenseQuery<IOrderEvent[]>({
+    queryKey: ["orderEvent"],
+    queryFn: () => apiGetOrderEvent(),
+    staleTime: Infinity,
+  });
+
+  const openedQuiz = quizList.find(
+    (quiz) => quiz.status === "OPEN",
+  ) as IOrderEvent;
+
+  const handlePhoneNumberChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const targetValue = phoneNumberAutoFormat(e.target.value);
+    setPhoneNumber(targetValue);
+  };
+
+  const handleSubmit = () => {
+    if (!localStorage.getItem("ApplyTicket") || !openedQuiz) {
+      alert("올바른 접근이 아닙니다.");
+      return;
+    }
+    if (phoneNumber === "") {
+      alert("전화번호를 입력해주세요");
+      return;
+    }
+    if (!isChecked) {
+      alert("약관에 동의해주세요.");
+      return;
+    }
+
+    apiPostOrderEventApply({
+      eventId: openedQuiz.eventId,
+      quizId: openedQuiz.quiz?.quizId as string,
+      phoneNumber: phoneNumber.replace(/-/g, ""),
+      appplyTicket: localStorage.getItem("ApplyTicket") as string,
+    }).then((response) => {
+      if (response.ok) {
+        openModal({
+          type: "alert",
+          props: {
+            title: MODAL_N_QUIZ_TITLE,
+            content: MODAL_CONTENT_ORDER_EVENT_APPLY_SUCCESS,
+          },
+        });
+      }
+    });
+  };
+
+  useEffect(() => {
+    if (!localStorage.getItem("ApplyTicket")) {
+      alert("권한이 없습니다.");
+      navigate(MAIN_PAGE_ROUTE);
+    }
+  }, [navigate]);
+
+  return (
+    <div css={backgroundStyle}>
+      <div css={logoContainerStyle}>
+        <NLogo css={logoStyle} />
+        <span css={titleStyle}>퀴즈</span>
+      </div>
+      <div css={centeredContainerStyle}>
+        <div css={rewardContainerStyle}>
+          <NQuizReward
+            imgSrc={openedQuiz.reward.imgSrc}
+            name={openedQuiz.reward.name}
+            startDate={openedQuiz.startDate}
+            status={openedQuiz.status}
+          />
+        </div>
+      </div>
+
+      <div css={contentContainerStyle}>
+        <div css={cheersTextStyle}>축하드립니다!</div>
+        <div css={contentTextStyle}>선착순 이벤트 대상자에 선정되었습니다!</div>
+        <div css={contentTextStyle}>아래 칸에 휴대폰 번호를 입력해주세요.</div>
+      </div>
+
+      <div css={inputContainerStyle}>
+        <input
+          css={inputStyle}
+          placeholder="전화번호 입력"
+          value={phoneNumber}
+          onChange={handlePhoneNumberChange}
+          type="tel"
+          maxLength={13}
+        />
+      </div>
+
+      <CheckBox
+        isChecked={isChecked}
+        setIsChecked={setIsChecked}
+        text="개인정보 수집 및 이용 약관에 동의합니다. (이벤트 참가자 식별 및 경품 발송)"
+      />
+      <ul css={listStyle}>
+        <li css={listItemStyle}>경품은 추후 문자를 통해 발송됩니다.</li>
+        <li css={listItemStyle}>
+          번호 제출 전 페이지를 이탈하면 당첨이 취소됩니다.
+        </li>
+      </ul>
+
+      <Button onClick={handleSubmit}>제출하기</Button>
+    </div>
+  );
+};

--- a/packages/service/src/pages/NQuizEventWinnerApply/index.ts
+++ b/packages/service/src/pages/NQuizEventWinnerApply/index.ts
@@ -1,0 +1,1 @@
+export { NQuizEventWinnerApply } from "./NQuizEventWinnerApply";

--- a/packages/service/src/pages/index.ts
+++ b/packages/service/src/pages/index.ts
@@ -4,3 +4,4 @@ export { NewCar } from "./NewCar";
 export { PartsCollection } from "./PartsCollection";
 export { PartsPick } from "./PartsPick";
 export { PickEvent } from "./PickEvent";
+export { NQuizEventWinnerApply } from "./NQuizEventWinnerApply";

--- a/packages/service/src/router.tsx
+++ b/packages/service/src/router.tsx
@@ -14,6 +14,7 @@ import {
   PICK_EVENT_PAGE_ROUTE,
   N_PARTS_PICK_PAGE_ROUTE,
   PARTS_COLLECTION_PAGE_ROUTE,
+  N_QUIZ_EVENT_PAGE_WINNER_APLLY_PAGE_ROUTE,
 } from "./constants/routes";
 import { RotateDemoPage } from "./Demo/pages/RotateDemoPage";
 import { AuthDemoPage } from "./Demo/pages/AuthDemoPage";
@@ -31,6 +32,7 @@ import {
   NewCar,
   PartsPick,
   PartsCollection,
+  NQuizEventWinnerApply,
 } from "./pages";
 
 export const router = createBrowserRouter([
@@ -44,6 +46,10 @@ export const router = createBrowserRouter([
       { path: NEW_CAR_PAGE_ROUTE, element: <NewCar /> },
       { path: N_PARTS_PICK_PAGE_ROUTE, element: <PartsPick /> },
       { path: PARTS_COLLECTION_PAGE_ROUTE, element: <PartsCollection /> },
+      {
+        path: N_QUIZ_EVENT_PAGE_WINNER_APLLY_PAGE_ROUTE,
+        element: <NQuizEventWinnerApply />,
+      },
     ],
   },
   {


### PR DESCRIPTION
# 🔗 연관된 이슈

- [연관된 이슈 링크](https://watermelon-clap.atlassian.net/browse/CLAP-67?atlOrigin=eyJpIjoiMmY2NTMyNDdhNmUyNDU1YWExMWRiYzE0ZGRmMjdkNzgiLCJwIjoiaiJ9)
  
<br/>

# 📗 작업 내용
선착순 이벤트 당첨 유저 정보 입력페이지 구현

### 변경 사항
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/a0f783c1-1c19-481e-8683-dc60f69baaee">

- 선착순 이벤트에 당첨이되면 기존에는 모달이 노출 -> 페이지 이동으로 전환
- 입력폼 구현 
- apI 연동

<br/>


# ✏️ 리뷰어 멘션
@thgee 
