### PR TITLE
Feat(CLAP-141): 응모 완료 페이지

### DIFF
--- a/packages/service/src/Demo/pages/ButtonDemoPage.tsx
+++ b/packages/service/src/Demo/pages/ButtonDemoPage.tsx
@@ -1,7 +1,6 @@
 import { Button, ButtonVariant } from "@service/common/components/Button";
 import { theme } from "@watermelon-clap/core/src/theme";
 import { css } from "@emotion/react";
-import { ClipBoardButton } from "@service/common/components/ClipBoardButton";
 import { CheckBox } from "@service/common/components/CheckBox";
 import { useState } from "react";
 import { ReactComponent as ClipBoardIcon } from "public/icons/clipboard.svg";
@@ -66,8 +65,6 @@ const ButtonDemoPage = () => {
         >
           button
         </Button>
-
-        <ClipBoardButton />
 
         <CheckBox
           isChecked={isChecked1}

--- a/packages/service/src/apis/expectation/apiPostExpectation.ts
+++ b/packages/service/src/apis/expectation/apiPostExpectation.ts
@@ -1,0 +1,17 @@
+import { customFetch, getAccessToken } from "@watermelon-clap/core/src/utils";
+
+export const apiPostExpectation = (expectation: string) =>
+  customFetch(
+    `
+    ${import.meta.env.VITE_BACK_BASE_URL}/expectations
+    `,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        expectation: expectation,
+      }),
+      headers: {
+        Authorization: `Bearer ${getAccessToken()}`,
+      },
+    },
+  );

--- a/packages/service/src/apis/expectation/apiPostExpectation.ts
+++ b/packages/service/src/apis/expectation/apiPostExpectation.ts
@@ -11,6 +11,7 @@ export const apiPostExpectation = (expectation: string) =>
         expectation: expectation,
       }),
       headers: {
+        "Content-Type": "application/json",
         Authorization: `Bearer ${getAccessToken()}`,
       },
     },

--- a/packages/service/src/apis/link/apiGetMyShareLink.ts
+++ b/packages/service/src/apis/link/apiGetMyShareLink.ts
@@ -1,0 +1,13 @@
+import { customFetch, getAccessToken } from "@watermelon-clap/core/src/utils";
+
+interface IApiGetMyShareLink {
+  link: string;
+}
+
+export const apiGetMyShareLink = (): Promise<IApiGetMyShareLink> => {
+  return customFetch(`${import.meta.env.VITE_BACK_BASE_URL}/link`, {
+    headers: {
+      Authorization: `Bearer ${getAccessToken()}`,
+    },
+  }).then((res) => res.json());
+};

--- a/packages/service/src/apis/lottery/apiGetLotteryStatus.ts
+++ b/packages/service/src/apis/lottery/apiGetLotteryStatus.ts
@@ -1,0 +1,13 @@
+import { customFetch } from "@watermelon-clap/core/src/utils";
+
+interface IApiGetLotteryStatus {
+  rank: number;
+  miniature: boolean;
+  applied: boolean;
+}
+
+export const apiGetLotteryStatus = (): Promise<IApiGetLotteryStatus> => {
+  return customFetch(
+    `${import.meta.env.VITE_BACK_BASE_URL}/event/lotteries/rank`,
+  ).then((res) => res.json());
+};

--- a/packages/service/src/apis/lottery/apiGetLotteryStatus.ts
+++ b/packages/service/src/apis/lottery/apiGetLotteryStatus.ts
@@ -1,4 +1,4 @@
-import { customFetch } from "@watermelon-clap/core/src/utils";
+import { customFetch, getAccessToken } from "@watermelon-clap/core/src/utils";
 
 interface IApiGetLotteryStatus {
   rank: number;
@@ -6,8 +6,11 @@ interface IApiGetLotteryStatus {
   applied: boolean;
 }
 
-export const apiGetLotteryStatus = (): Promise<IApiGetLotteryStatus> => {
-  return customFetch(
-    `${import.meta.env.VITE_BACK_BASE_URL}/event/lotteries/rank`,
-  ).then((res) => res.json());
-};
+export const apiGetLotteryStatus = (): Promise<IApiGetLotteryStatus> =>
+  customFetch(`${import.meta.env.VITE_BACK_BASE_URL}/event/lotteries/rank`, {
+    headers: {
+      Authorization: `Bearer ${getAccessToken()}`,
+    },
+  }).then((res) => {
+    return res.json();
+  });

--- a/packages/service/src/common/components/ClipBoardButton/ClipBoardButton.tsx
+++ b/packages/service/src/common/components/ClipBoardButton/ClipBoardButton.tsx
@@ -9,7 +9,7 @@ import {
 import { ReactComponent as ClipBoardIcon } from "public/icons/clipboard.svg";
 
 interface IClipBoardButton {
-  copyRef: React.MutableRefObject<null>;
+  copyRef: any;
 }
 const ClipBoardButton = ({ copyRef }: IClipBoardButton) => {
   const [isCliped, setIsCliped] = useState<boolean>(false);
@@ -18,7 +18,7 @@ const ClipBoardButton = ({ copyRef }: IClipBoardButton) => {
 
   const handleCopy = () => {
     const textToCopy = copyRef?.current?.textContent;
-    navigator.clipboard.writeText(textToCopy);
+    navigator.clipboard.writeText(textToCopy as string);
   };
 
   return (

--- a/packages/service/src/common/components/ClipBoardButton/ClipBoardButton.tsx
+++ b/packages/service/src/common/components/ClipBoardButton/ClipBoardButton.tsx
@@ -8,51 +8,61 @@ import {
 } from "./ClipBoardButton.css";
 import { ReactComponent as ClipBoardIcon } from "public/icons/clipboard.svg";
 
-const ClipBoardButton = () => {
+interface IClipBoardButton {
+  copyRef: React.MutableRefObject<null>;
+}
+const ClipBoardButton = ({ copyRef }: IClipBoardButton) => {
   const [isCliped, setIsCliped] = useState<boolean>(false);
   const initialText = "클립보드에 복사";
   const changeText = "복사되었습니다!";
 
+  const handleCopy = () => {
+    const textToCopy = copyRef?.current?.textContent;
+    navigator.clipboard.writeText(textToCopy);
+  };
+
   return (
-    <AnimatePresence mode="wait">
-      {isCliped ? (
-        <motion.button
-          css={clipButtonSuccessStyle}
-          onClick={() => setIsCliped(false)}
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-        >
-          <motion.span
-            css={clipButtonSuccessContentStyle}
-            key="action"
-            initial={{ y: -50 }}
-            animate={{ y: 0 }}
+    <div onClick={handleCopy}>
+      <AnimatePresence mode="wait">
+        {isCliped ? (
+          <motion.button
+            css={clipButtonSuccessStyle}
+            onClick={() => setIsCliped(false)}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
           >
-            <ClipBoardIcon />
-            {changeText}
-          </motion.span>
-        </motion.button>
-      ) : (
-        <motion.button
-          css={clipButtonStyle}
-          onClick={() => setIsCliped(true)}
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-        >
-          <motion.span
-            css={clipButtonContentStyle}
-            key="reaction"
-            initial={{ x: 0 }}
-            exit={{ x: 50, transition: { duration: 0.1 } }}
+            <motion.span
+              css={clipButtonSuccessContentStyle}
+              key="action"
+              initial={{ y: -50 }}
+              animate={{ y: 0 }}
+            >
+              <ClipBoardIcon />
+              {changeText}
+            </motion.span>
+          </motion.button>
+        ) : (
+          <motion.button
+            css={clipButtonStyle}
+            onClick={() => setIsCliped(true)}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
           >
-            <ClipBoardIcon />
-            {initialText}
-          </motion.span>
-        </motion.button>
-      )}
-    </AnimatePresence>
+            <motion.span
+              css={clipButtonContentStyle}
+              key="reaction"
+              initial={{ x: 0 }}
+              exit={{ x: 50, transition: { duration: 0.1 } }}
+            >
+              <ClipBoardIcon />
+              {initialText}
+            </motion.span>
+          </motion.button>
+        )}
+      </AnimatePresence>
+    </div>
   );
 };
 

--- a/packages/service/src/components/main/EventPeriod/Timer/Timer.css.ts
+++ b/packages/service/src/components/main/EventPeriod/Timer/Timer.css.ts
@@ -15,7 +15,7 @@ export const staticCardStyles = (position: "upper" | "lower") => css`
 `;
 
 export const textStyles = (translateY?: string, title?: string) => css`
-  font-family: "PyeongChang Peace";
+  ${theme.font.pcpL}
   font-size: calc(20px + 3vw);
   -webkit-text-stroke-width: 2px;
   font-weight: normal;
@@ -96,6 +96,7 @@ export const rendererWrap2 = css`
   align-items: center;
   gap: calc(10px + 2vw);
   justify-content: center;
+
   ${mobile(css`
     gap: 0.3rem;
   `)};

--- a/packages/service/src/constants/routes.ts
+++ b/packages/service/src/constants/routes.ts
@@ -16,3 +16,4 @@ export const PARTS_COLLECTION_PAGE_ROUTE = "/parts-collection" as const;
 export const SHARE_PAGE_ROUTE = "/share/:linkKey" as const;
 export const N_QUIZ_EVENT_PAGE_WINNER_APLLY_PAGE_ROUTE =
   "/quiz-event-apply" as const;
+export const LOTTER_APPLY_FINISH_PAGE_ROUTE = "/lottery/apply-finish" as const;

--- a/packages/service/src/index.tsx
+++ b/packages/service/src/index.tsx
@@ -23,6 +23,6 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
       <RouterProvider router={router} />
       <ModalContainer />
     </ModalProvider>
-    <ReactQueryDevtools initialIsOpen={false} />s
+    <ReactQueryDevtools initialIsOpen={false} />
   </QueryClientProvider>,
 );

--- a/packages/service/src/pages/LotteryApplyFinish/LotteryApplyFinish.css.ts
+++ b/packages/service/src/pages/LotteryApplyFinish/LotteryApplyFinish.css.ts
@@ -1,0 +1,69 @@
+import { css } from "@emotion/react";
+import { mobile } from "@service/common/responsive/responsive";
+import { theme } from "@watermelon-clap/core/src/theme";
+
+export const mainBg = css`
+  background-image: url("/images/common/main-bg.webp");
+  background-size: cover;
+  padding-bottom: 200px;
+
+  color: white;
+`;
+
+export const pageTitle = css`
+  text-align: center;
+  ${theme.font.pcpB}
+  font-size : calc(50px + 2vw);
+  padding-top: 120px;
+  color: ${theme.color.white};
+
+  ${mobile(css`
+    font-size: calc(20px + 2vw);
+    padding: 100px 0 50px 0;
+  `)}
+`;
+export const applyBtn = css`
+  padding: 50px 50px;
+  height: 100px;
+
+  width: fit-content;
+`;
+
+export const btn = css`
+  margin: 0 auto;
+  background-color: ${theme.color.gray100};
+  color: black;
+  ${theme.font.preB}
+  font-size : 24px;
+
+  &:hover {
+    background-color: ${theme.color.gray200};
+  }
+  ${mobile(css`
+    width: fit-content;
+    padding: 10px 20px;
+  `)}
+`;
+
+export const shareLinkBox = css`
+  background-color: ${theme.color.gray100};
+  color: ${theme.color.gray300};
+  ${theme.font.preM14}
+  border-radius: 10px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding: 16px 18px;
+
+  width: 400px;
+`;
+
+export const expectationInput = css`
+  padding: 18px;
+  height: 100px;
+  resize: none;
+  width: 600px;
+  border-radius: 14px;
+  background-color: ${theme.color.gray100};
+  outline: none;
+`;

--- a/packages/service/src/pages/LotteryApplyFinish/LotteryApplyFinish.css.ts
+++ b/packages/service/src/pages/LotteryApplyFinish/LotteryApplyFinish.css.ts
@@ -22,9 +22,18 @@ export const pageTitle = css`
     padding: 100px 0 50px 0;
   `)}
 `;
-export const applyBtn = css`
+export const applyBtn = (isExpectationNull: boolean) => css`
   padding: 50px 50px;
   height: 100px;
+  background-color: ${isExpectationNull
+    ? theme.color.gray400
+    : theme.color.eventBlue};
+  color: ${isExpectationNull ? theme.color.gray300 : theme.color.white};
+  cursor: ${isExpectationNull ? "default" : "pointer"};
+
+  &:active {
+    background-color: ${isExpectationNull && theme.color.gray400};
+  }
 
   width: fit-content;
 `;

--- a/packages/service/src/pages/LotteryApplyFinish/LotteryApplyFinish.css.ts
+++ b/packages/service/src/pages/LotteryApplyFinish/LotteryApplyFinish.css.ts
@@ -8,6 +8,10 @@ export const mainBg = css`
   padding-bottom: 200px;
 
   color: white;
+
+  ${mobile(css`
+    padding-bottom: 100px;
+  `)}
 `;
 
 export const pageTitle = css`
@@ -38,6 +42,13 @@ export const applyBtn = (isExpectationNull: boolean) => css`
   width: fit-content;
 `;
 
+export const sectionTitle = css`
+  ${theme.font.pcB28};
+  ${mobile(css`
+    font-size: 24px;
+  `)}
+`;
+
 export const btn = css`
   margin: 0 auto;
   background-color: ${theme.color.gray100};
@@ -49,8 +60,8 @@ export const btn = css`
     background-color: ${theme.color.gray200};
   }
   ${mobile(css`
-    width: fit-content;
     padding: 10px 20px;
+    width: 200px;
   `)}
 `;
 
@@ -63,8 +74,12 @@ export const shareLinkBox = css`
   overflow: hidden;
   text-overflow: ellipsis;
   padding: 16px 18px;
-
   width: 400px;
+
+  ${mobile(css`
+    width: 100%;
+    padding: 10px;
+  `)}
 `;
 
 export const expectationInput = css`
@@ -75,4 +90,8 @@ export const expectationInput = css`
   border-radius: 14px;
   background-color: ${theme.color.gray100};
   outline: none;
+
+  ${mobile(css`
+    width: 100%;
+  `)}
 `;

--- a/packages/service/src/pages/LotteryApplyFinish/LotteryApplyFinish.tsx
+++ b/packages/service/src/pages/LotteryApplyFinish/LotteryApplyFinish.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import * as style from "./LotteryApplyFinish.css";
 import { Button, ButtonVariant } from "@service/common/components/Button";
 import { ClipBoardButton } from "@service/common/components/ClipBoardButton";
@@ -22,6 +22,9 @@ export const LotteryApplyFinish = () => {
   const [isPostExpectation, setIsPostExpectation] = useState(false);
 
   const { openModal } = useModal();
+  const {
+    state: { isApplied },
+  } = useLocation();
 
   useEffect(() => {
     apiGetMyShareLink().then(({ link }) => {
@@ -121,51 +124,53 @@ export const LotteryApplyFinish = () => {
 
         <Space size={40} />
 
-        <div
-          css={[
-            theme.flex.column,
-            css`
-              align-items: start;
-              gap: 24px;
-            `,
-          ]}
-        >
-          <span css={style.sectionTitle}>
-            새롭게 출시된 아반떼 N에 대한 기대평을 남겨주세요 🥳
-          </span>
-          <span css={theme.font.preM18}>
-            남겨주신 기대평은 홈화면에 노출될 수 있습니다! 최대 50자까지 작성할
-            수 있어요.
-          </span>
-
-          <form
-            onSubmit={handleSubmit}
+        {isApplied || (
+          <div
             css={[
-              theme.flex.center,
-              theme.gap.gap16,
-              mobile(css`
-                flex-direction: column;
-                width: 100%;
-              `),
+              theme.flex.column,
+              css`
+                align-items: start;
+                gap: 24px;
+              `,
             ]}
           >
-            <textarea
-              placeholder="여기에 기대평을 작성해주세요"
-              css={style.expectationInput}
-              value={expectation}
-              onChange={handleChange}
-              disabled={isPostExpectation && true}
-            />
-            <Button
-              type="submit"
-              variant={ButtonVariant.LONG}
-              css={style.applyBtn(isExpectationNull)}
-              disabled={isExpectationNull}
+            <span css={style.sectionTitle}>
+              새롭게 출시된 아반떼 N에 대한 기대평을 남겨주세요 🥳
+            </span>
+            <span css={theme.font.preM18}>
+              남겨주신 기대평은 홈화면에 노출될 수 있습니다! 최대 50자까지
+              작성할 수 있어요.
+            </span>
+
+            <form
+              onSubmit={handleSubmit}
+              css={[
+                theme.flex.center,
+                theme.gap.gap16,
+                mobile(css`
+                  flex-direction: column;
+                  width: 100%;
+                `),
+              ]}
             >
-              제출하기
-            </Button>
-          </form>
-        </div>
+              <textarea
+                placeholder="여기에 기대평을 작성해주세요"
+                css={style.expectationInput}
+                value={expectation}
+                onChange={handleChange}
+                disabled={isPostExpectation && true}
+              />
+              <Button
+                type="submit"
+                variant={ButtonVariant.LONG}
+                css={style.applyBtn(isExpectationNull)}
+                disabled={isExpectationNull}
+              >
+                제출하기
+              </Button>
+            </form>
+          </div>
+        )}
       </section>
 
       <Space size={100} />

--- a/packages/service/src/pages/LotteryApplyFinish/LotteryApplyFinish.tsx
+++ b/packages/service/src/pages/LotteryApplyFinish/LotteryApplyFinish.tsx
@@ -6,19 +6,34 @@ import { theme } from "@watermelon-clap/core/src/theme";
 import { Space } from "@service/common/styles/Space";
 import { css } from "@emotion/react";
 import { MAIN_PAGE_ROUTE } from "@service/constants/routes";
-import { useEffect, useRef, useState } from "react";
+import { ChangeEvent, useEffect, useRef, useState } from "react";
 import { apiGetMyShareLink } from "@service/apis/link/apiGetMyShareLink";
 
 export const LotteryApplyFinish = () => {
   const navigate = useNavigate();
   const shareLinkRef = useRef(null);
   const [shareLink, setShareLink] = useState<string>();
+  const [expectation, setExpectation] = useState("");
+  const [isExpectationNull, setIsExpectationNull] = useState(true);
 
   useEffect(() => {
     apiGetMyShareLink().then(({ link }) => {
       setShareLink(link);
     });
   }, []);
+
+  const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    const text = event.currentTarget.value;
+    setIsExpectationNull(!text.length ? true : false);
+    setExpectation(text);
+  };
+  console.log(isExpectationNull);
+
+  const handleSubmit = async () => {
+    if (!expectation) {
+      return;
+    }
+  };
 
   return (
     <div css={style.mainBg}>
@@ -78,15 +93,25 @@ export const LotteryApplyFinish = () => {
             수 있어요.
           </span>
 
-          <div css={[theme.flex.center, theme.gap.gap16]}>
+          <form
+            onSubmit={handleSubmit}
+            css={[theme.flex.center, theme.gap.gap16]}
+          >
             <textarea
               placeholder="여기에 기대평을 작성해주세요"
               css={style.expectationInput}
+              value={expectation}
+              onChange={handleChange}
             />
-            <Button variant={ButtonVariant.LONG} css={style.applyBtn}>
+            <Button
+              type="submit"
+              variant={ButtonVariant.LONG}
+              css={style.applyBtn(isExpectationNull)}
+              disabled={isExpectationNull}
+            >
               제출하기
             </Button>
-          </div>
+          </form>
         </div>
       </section>
 

--- a/packages/service/src/pages/LotteryApplyFinish/LotteryApplyFinish.tsx
+++ b/packages/service/src/pages/LotteryApplyFinish/LotteryApplyFinish.tsx
@@ -11,31 +11,52 @@ export const LotteryApplyFinish = () => {
   const navigator = useNavigate();
   return (
     <div css={style.mainBg}>
-      <section>
-        <h1 css={style.pageTitle}>응모완료</h1>
-        <span>이벤트에 응모되었습니다.</span>
-      </section>
+      <h1 css={style.pageTitle}>응모완료</h1>
+
+      <Space size={100} />
 
       <section
-        css={css`
-          margin: 0 auto;
-        `}
+        css={[
+          theme.flex.column,
+          css`
+            margin: 0 auto;
+            width: 70%;
+            max-width: 1000px;
+            justify-content: start;
+            align-items: start;
+          `,
+        ]}
       >
-        <div>
-          <span>내 컬렉션 URL</span>
+        <div
+          css={[
+            theme.flex.column,
+            css`
+              align-items: start;
+              gap: 14px;
+            `,
+          ]}
+        >
+          <span css={theme.font.pcB28}>내 컬렉션 URL</span>
           <span>
             링크를 통해 친구가 이벤트를 참여하면 추가 뽑기권을 드려요!
           </span>
-
           <div css={[theme.flex.center, theme.gap.gap12]}>
             <div css={style.shareLinkBox}>공유링크</div>
             <ClipBoardButton />
           </div>
         </div>
 
-        <Space size={100} />
+        <Space size={40} />
 
-        <div>
+        <div
+          css={[
+            theme.flex.column,
+            css`
+              align-items: start;
+              gap: 14px;
+            `,
+          ]}
+        >
           <span css={theme.font.pcB28}>
             새롭게 출시된 아반떼 N에 대한 기대평을 남겨주세요 🥳
           </span>
@@ -44,7 +65,7 @@ export const LotteryApplyFinish = () => {
             수 있어요.
           </span>
 
-          <div css={[theme.flex.center, theme.gap.gap12]}>
+          <div css={[theme.flex.center, theme.gap.gap16]}>
             <textarea
               placeholder="여기에 기대평을 작성해주세요"
               css={style.expectationInput}

--- a/packages/service/src/pages/LotteryApplyFinish/LotteryApplyFinish.tsx
+++ b/packages/service/src/pages/LotteryApplyFinish/LotteryApplyFinish.tsx
@@ -10,6 +10,8 @@ import { ChangeEvent, useEffect, useRef, useState } from "react";
 import { apiGetMyShareLink } from "@service/apis/link/apiGetMyShareLink";
 import { apiPostExpectation } from "@service/apis/expectation/apiPostExpectation";
 import { useModal } from "@watermelon-clap/core/src/hooks";
+import { mobile } from "@service/common/responsive/responsive";
+import { useMobile } from "@service/common/hooks/useMobile";
 
 export const LotteryApplyFinish = () => {
   const navigate = useNavigate();
@@ -65,11 +67,13 @@ export const LotteryApplyFinish = () => {
       );
   };
 
+  const isMobile = useMobile();
+
   return (
     <div css={style.mainBg}>
       <h1 css={style.pageTitle}>응모완료</h1>
 
-      <Space size={100} />
+      <Space size={isMobile ? 40 : 100} />
 
       <section
         css={[
@@ -89,14 +93,25 @@ export const LotteryApplyFinish = () => {
             css`
               align-items: start;
               gap: 14px;
+              width: 100%;
             `,
           ]}
         >
-          <span css={theme.font.pcB28}>내 컬렉션 URL</span>
+          <span css={style.sectionTitle}>내 컬렉션 URL</span>
           <span>
             링크를 통해 친구가 이벤트를 참여하면 추가 뽑기권을 드려요!
           </span>
-          <div css={[theme.flex.center, theme.gap.gap12]}>
+          <div
+            css={[
+              theme.flex.center,
+              theme.gap.gap12,
+              mobile(css`
+                flex-direction: column;
+                width: 100%;
+                align-items: start;
+              `),
+            ]}
+          >
             <div css={style.shareLinkBox} ref={shareLinkRef}>
               {shareLink}
             </div>
@@ -111,11 +126,11 @@ export const LotteryApplyFinish = () => {
             theme.flex.column,
             css`
               align-items: start;
-              gap: 14px;
+              gap: 24px;
             `,
           ]}
         >
-          <span css={theme.font.pcB28}>
+          <span css={style.sectionTitle}>
             새롭게 출시된 아반떼 N에 대한 기대평을 남겨주세요 🥳
           </span>
           <span css={theme.font.preM18}>
@@ -125,7 +140,14 @@ export const LotteryApplyFinish = () => {
 
           <form
             onSubmit={handleSubmit}
-            css={[theme.flex.center, theme.gap.gap16]}
+            css={[
+              theme.flex.center,
+              theme.gap.gap16,
+              mobile(css`
+                flex-direction: column;
+                width: 100%;
+              `),
+            ]}
           >
             <textarea
               placeholder="여기에 기대평을 작성해주세요"

--- a/packages/service/src/pages/LotteryApplyFinish/LotteryApplyFinish.tsx
+++ b/packages/service/src/pages/LotteryApplyFinish/LotteryApplyFinish.tsx
@@ -6,9 +6,20 @@ import { theme } from "@watermelon-clap/core/src/theme";
 import { Space } from "@service/common/styles/Space";
 import { css } from "@emotion/react";
 import { MAIN_PAGE_ROUTE } from "@service/constants/routes";
+import { useEffect, useRef, useState } from "react";
+import { apiGetMyShareLink } from "@service/apis/link/apiGetMyShareLink";
 
 export const LotteryApplyFinish = () => {
-  const navigator = useNavigate();
+  const navigate = useNavigate();
+  const shareLinkRef = useRef(null);
+  const [shareLink, setShareLink] = useState<string>();
+
+  useEffect(() => {
+    apiGetMyShareLink().then(({ link }) => {
+      setShareLink(link);
+    });
+  }, []);
+
   return (
     <div css={style.mainBg}>
       <h1 css={style.pageTitle}>응모완료</h1>
@@ -41,8 +52,10 @@ export const LotteryApplyFinish = () => {
             링크를 통해 친구가 이벤트를 참여하면 추가 뽑기권을 드려요!
           </span>
           <div css={[theme.flex.center, theme.gap.gap12]}>
-            <div css={style.shareLinkBox}>공유링크</div>
-            <ClipBoardButton />
+            <div css={style.shareLinkBox} ref={shareLinkRef}>
+              {shareLink}
+            </div>
+            <ClipBoardButton copyRef={shareLinkRef} />
           </div>
         </div>
 
@@ -82,7 +95,7 @@ export const LotteryApplyFinish = () => {
       <Button
         variant={ButtonVariant.LONG}
         css={style.btn}
-        onClick={() => navigator(MAIN_PAGE_ROUTE)}
+        onClick={() => navigate(MAIN_PAGE_ROUTE)}
       >
         홈으로 가기
       </Button>

--- a/packages/service/src/pages/LotteryApplyFinish/LotteryApplyFinish.tsx
+++ b/packages/service/src/pages/LotteryApplyFinish/LotteryApplyFinish.tsx
@@ -31,7 +31,10 @@ export const LotteryApplyFinish = () => {
     const text = event.currentTarget.value;
     setIsExpectationNull(!text.length ? true : false);
     if (text.length >= 50) {
-      alert("기대평은 50자 이내 작성 가능합니다.");
+      openModal({
+        type: "alert",
+        props: { content: "기대평은 50자 이내 작성 가능합니다" },
+      });
       return;
     }
     setExpectation(text);

--- a/packages/service/src/pages/LotteryApplyFinish/LotteryApplyFinish.tsx
+++ b/packages/service/src/pages/LotteryApplyFinish/LotteryApplyFinish.tsx
@@ -8,6 +8,8 @@ import { css } from "@emotion/react";
 import { MAIN_PAGE_ROUTE } from "@service/constants/routes";
 import { ChangeEvent, useEffect, useRef, useState } from "react";
 import { apiGetMyShareLink } from "@service/apis/link/apiGetMyShareLink";
+import { apiPostExpectation } from "@service/apis/expectation/apiPostExpectation";
+import { useModal } from "@watermelon-clap/core/src/hooks";
 
 export const LotteryApplyFinish = () => {
   const navigate = useNavigate();
@@ -15,6 +17,9 @@ export const LotteryApplyFinish = () => {
   const [shareLink, setShareLink] = useState<string>();
   const [expectation, setExpectation] = useState("");
   const [isExpectationNull, setIsExpectationNull] = useState(true);
+  const [isPostExpectation, setIsPostExpectation] = useState(false);
+
+  const { openModal } = useModal();
 
   useEffect(() => {
     apiGetMyShareLink().then(({ link }) => {
@@ -25,14 +30,36 @@ export const LotteryApplyFinish = () => {
   const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
     const text = event.currentTarget.value;
     setIsExpectationNull(!text.length ? true : false);
+    if (text.length >= 50) {
+      alert("기대평은 50자 이내 작성 가능합니다.");
+      return;
+    }
     setExpectation(text);
   };
-  console.log(isExpectationNull);
 
-  const handleSubmit = async () => {
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
     if (!expectation) {
       return;
     }
+
+    apiPostExpectation(expectation)
+      .then(() => {
+        openModal({
+          type: "alert",
+          props: {
+            content: "기대평을 성공적으로 등록하였습니다",
+          },
+        });
+        setIsPostExpectation(true);
+        setIsExpectationNull(true);
+      })
+      .catch(() =>
+        openModal({
+          type: "alert",
+          props: { content: "기대평 등록에 실패했습니다" },
+        }),
+      );
   };
 
   return (
@@ -102,6 +129,7 @@ export const LotteryApplyFinish = () => {
               css={style.expectationInput}
               value={expectation}
               onChange={handleChange}
+              disabled={isPostExpectation && true}
             />
             <Button
               type="submit"

--- a/packages/service/src/pages/LotteryApplyFinish/LotteryApplyFinish.tsx
+++ b/packages/service/src/pages/LotteryApplyFinish/LotteryApplyFinish.tsx
@@ -1,0 +1,70 @@
+import { useNavigate } from "react-router-dom";
+import * as style from "./LotteryApplyFinish.css";
+import { Button, ButtonVariant } from "@service/common/components/Button";
+import { ClipBoardButton } from "@service/common/components/ClipBoardButton";
+import { theme } from "@watermelon-clap/core/src/theme";
+import { Space } from "@service/common/styles/Space";
+import { css } from "@emotion/react";
+import { MAIN_PAGE_ROUTE } from "@service/constants/routes";
+
+export const LotteryApplyFinish = () => {
+  const navigator = useNavigate();
+  return (
+    <div css={style.mainBg}>
+      <section>
+        <h1 css={style.pageTitle}>응모완료</h1>
+        <span>이벤트에 응모되었습니다.</span>
+      </section>
+
+      <section
+        css={css`
+          margin: 0 auto;
+        `}
+      >
+        <div>
+          <span>내 컬렉션 URL</span>
+          <span>
+            링크를 통해 친구가 이벤트를 참여하면 추가 뽑기권을 드려요!
+          </span>
+
+          <div css={[theme.flex.center, theme.gap.gap12]}>
+            <div css={style.shareLinkBox}>공유링크</div>
+            <ClipBoardButton />
+          </div>
+        </div>
+
+        <Space size={100} />
+
+        <div>
+          <span css={theme.font.pcB28}>
+            새롭게 출시된 아반떼 N에 대한 기대평을 남겨주세요 🥳
+          </span>
+          <span css={theme.font.preM18}>
+            남겨주신 기대평은 홈화면에 노출될 수 있습니다! 최대 50자까지 작성할
+            수 있어요.
+          </span>
+
+          <div css={[theme.flex.center, theme.gap.gap12]}>
+            <textarea
+              placeholder="여기에 기대평을 작성해주세요"
+              css={style.expectationInput}
+            />
+            <Button variant={ButtonVariant.LONG} css={style.applyBtn}>
+              제출하기
+            </Button>
+          </div>
+        </div>
+      </section>
+
+      <Space size={100} />
+
+      <Button
+        variant={ButtonVariant.LONG}
+        css={style.btn}
+        onClick={() => navigator(MAIN_PAGE_ROUTE)}
+      >
+        홈으로 가기
+      </Button>
+    </div>
+  );
+};

--- a/packages/service/src/pages/LotteryApplyFinish/index.ts
+++ b/packages/service/src/pages/LotteryApplyFinish/index.ts
@@ -1,0 +1,1 @@
+export { LotteryApplyFinish } from "./LotteryApplyFinish";

--- a/packages/service/src/pages/PartsPick/PartsPick.tsx
+++ b/packages/service/src/pages/PartsPick/PartsPick.tsx
@@ -10,8 +10,10 @@ import { useEffect, useRef, useState } from "react";
 import { useModal } from "@watermelon-clap/core/src/hooks";
 import { useAuth } from "@watermelon-clap/core/src/hooks";
 import { useMobile } from "@service/common/hooks/useMobile";
-import { useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { apiGetPartsRemain } from "@service/apis/partsEvent";
+import { LOTTER_APPLY_FINISH_PAGE_ROUTE } from "@service/constants/routes";
+import { apiGetLotteryStatus } from "@service/apis/lottery/apiGetLotteryStatus";
 
 export const PartsPick = () => {
   const { openModal } = useModal();
@@ -22,6 +24,8 @@ export const PartsPick = () => {
     useLocation()?.state?.remainChance,
   );
   const { getIsLogin, login } = useAuth();
+  const navigate = useNavigate();
+  const isApplied = useRef(false);
 
   const minusRemainChance = () => {
     if (remainChance < 1) return;
@@ -64,6 +68,8 @@ export const PartsPick = () => {
     if (!getIsLogin()) {
       login().then(handleSetRemianChance);
     }
+
+    apiGetLotteryStatus().then(({ applied }) => (isApplied.current = applied));
   }, []);
 
   return (
@@ -82,7 +88,11 @@ export const PartsPick = () => {
             <Button
               variant={ButtonVariant.LONG}
               css={partsPickButtonStyle}
-              onClick={() => {}}
+              onClick={() => {
+                navigate(LOTTER_APPLY_FINISH_PAGE_ROUTE, {
+                  state: { isApplied: isApplied.current },
+                });
+              }}
             >
               URL 공유하고 아반떼 N 받으러 가기
             </Button>

--- a/packages/service/src/router.tsx
+++ b/packages/service/src/router.tsx
@@ -16,6 +16,7 @@ import {
   PARTS_COLLECTION_PAGE_ROUTE,
   SHARE_PAGE_ROUTE,
   N_QUIZ_EVENT_PAGE_WINNER_APLLY_PAGE_ROUTE,
+  LOTTER_APPLY_FINISH_PAGE_ROUTE,
 } from "./constants/routes";
 import { RotateDemoPage } from "./Demo/pages/RotateDemoPage";
 import { AuthDemoPage } from "./Demo/pages/AuthDemoPage";
@@ -36,6 +37,7 @@ import {
   Share,
   NQuizEventWinnerApply,
 } from "./pages";
+import { LotteryApplyFinish } from "./pages/LotteryApplyFinish";
 
 export const router = createBrowserRouter([
   {
@@ -52,6 +54,10 @@ export const router = createBrowserRouter([
       {
         path: N_QUIZ_EVENT_PAGE_WINNER_APLLY_PAGE_ROUTE,
         element: <NQuizEventWinnerApply />,
+      },
+      {
+        path: LOTTER_APPLY_FINISH_PAGE_ROUTE,
+        element: <LotteryApplyFinish />,
       },
     ],
   },


### PR DESCRIPTION
# 🔗 연관된 이슈

- [연관된 이슈 링크](이슈 링크를 이곳에 넣어주세요.)
  
<br/>

# 📗 작업 내용

### 이슈 내용
- 파츠뽑기 후 공유링크, 기대평 작성 등의 작업을 수행할 응모완료 페이지 구현


### 변경 사항
- 기대평 제출 후 제출버튼을 비활성화 하였습니다.
- 이미 응모했던 사람이 페이지에 접속 시 기대평 입력란이 보이지 않게 하였습니다.


### [PC]

![image](https://github.com/user-attachments/assets/abe6b7b1-d167-43b2-a2d2-c67f437b80bb)


### [Mobile]

![image](https://github.com/user-attachments/assets/04c03c6d-db2b-4f64-829d-c8a00c4b1e29)



<br/>


# ✏️ 리뷰어 멘션

- @DaeWon9 
