### PR TITLE
feat(CLAP-142): 응모 내역 확인 페이지

### DIFF
--- a/packages/service/src/apis/lottery/apiGetLotteryStatus.ts
+++ b/packages/service/src/apis/lottery/apiGetLotteryStatus.ts
@@ -1,4 +1,4 @@
-import { customFetch } from "@watermelon-clap/core/src/utils";
+import { customFetch, getAccessToken } from "@watermelon-clap/core/src/utils";
 
 interface IApiGetLotteryStatus {
   rank: number;
@@ -9,5 +9,10 @@ interface IApiGetLotteryStatus {
 export const apiGetLotteryStatus = (): Promise<IApiGetLotteryStatus> => {
   return customFetch(
     `${import.meta.env.VITE_BACK_BASE_URL}/event/lotteries/rank`,
+    {
+      headers: {
+        Authorization: `Bearer ${getAccessToken()}`,
+      },
+    },
   ).then((res) => res.json());
 };

--- a/packages/service/src/common/components/GlobalNavigationBar/GlobalNavs/GlobalNavs.tsx
+++ b/packages/service/src/common/components/GlobalNavigationBar/GlobalNavs/GlobalNavs.tsx
@@ -7,6 +7,7 @@ import {
   PICK_EVENT_PAGE_ROUTE,
   N_QUIZ_EVENT_PAGE_ROUTE,
   PARTS_COLLECTION_PAGE_ROUTE,
+  LOTTER_APPLY_INFO_PAGE_ROUTE,
 } from "@service/constants/routes";
 
 const GlobalNavs = ({ isOpen }: { isOpen: boolean }) => {
@@ -44,7 +45,10 @@ const GlobalNavs = ({ isOpen }: { isOpen: boolean }) => {
       >
         내 컬렉션
       </div>
-      <div css={linkStyles} onClick={() => handleNavigation("#")}>
+      <div
+        css={linkStyles}
+        onClick={() => handleNavigation(LOTTER_APPLY_INFO_PAGE_ROUTE)}
+      >
         응모 내역 확인
       </div>
     </div>

--- a/packages/service/src/constants/routes.ts
+++ b/packages/service/src/constants/routes.ts
@@ -17,3 +17,4 @@ export const SHARE_PAGE_ROUTE = "/share/:linkKey" as const;
 export const N_QUIZ_EVENT_PAGE_WINNER_APLLY_PAGE_ROUTE =
   "/quiz-event-apply" as const;
 export const LOTTER_APPLY_FINISH_PAGE_ROUTE = "/lottery/apply-finish" as const;
+export const LOTTER_APPLY_INFO_PAGE_ROUTE = "/lottery/apply-info" as const;

--- a/packages/service/src/pages/LotteryApplyFinish/LotteryApplyFinish.css.ts
+++ b/packages/service/src/pages/LotteryApplyFinish/LotteryApplyFinish.css.ts
@@ -67,7 +67,7 @@ export const btn = css`
 
 export const shareLinkBox = css`
   background-color: ${theme.color.gray100};
-  color: ${theme.color.gray300};
+  color: ${theme.color.gray500};
   ${theme.font.preM14}
   border-radius: 10px;
   white-space: nowrap;

--- a/packages/service/src/pages/LotteryApplyInfo/LotteryApplyInfo.css.ts
+++ b/packages/service/src/pages/LotteryApplyInfo/LotteryApplyInfo.css.ts
@@ -23,7 +23,7 @@ export const pageTitle = css`
 
   ${mobile(css`
     font-size: calc(20px + 2vw);
-    padding: 100px 0 50px 0;
+    padding: 100px 0 20px 0;
   `)}
 `;
 
@@ -31,6 +31,10 @@ export const subtitle = css`
   ${theme.font.preB}
   font-size : calc(16px + 0.5vw);
   text-align: center;
+
+  ${mobile(css`
+    font-size: calc(14px);
+  `)}
 `;
 
 export const sectionTitle = css`

--- a/packages/service/src/pages/LotteryApplyInfo/LotteryApplyInfo.css.ts
+++ b/packages/service/src/pages/LotteryApplyInfo/LotteryApplyInfo.css.ts
@@ -1,0 +1,69 @@
+import { css } from "@emotion/react";
+import { mobile } from "@service/common/responsive/responsive";
+import { theme } from "@watermelon-clap/core/src/theme";
+
+export const mainBg = css`
+  background-image: url("/images/common/main-bg.webp");
+  background-size: cover;
+  padding-bottom: 200px;
+
+  color: white;
+
+  ${mobile(css`
+    padding-bottom: 100px;
+  `)}
+`;
+
+export const pageTitle = css`
+  text-align: center;
+  ${theme.font.pcpB}
+  font-size : calc(50px + 2vw);
+  padding-top: 120px;
+  color: ${theme.color.white};
+
+  ${mobile(css`
+    font-size: calc(20px + 2vw);
+    padding: 100px 0 50px 0;
+  `)}
+`;
+
+export const subtitle = css`
+  ${theme.font.preB}
+  font-size : calc(16px + 0.5vw);
+  text-align: center;
+`;
+
+export const sectionTitle = css`
+  ${theme.font.pcB28};
+  ${mobile(css`
+    font-size: 24px;
+  `)}
+`;
+
+export const btn = css`
+  margin: 0 auto;
+  ${theme.font.preB}
+  font-size : 24px;
+
+  ${mobile(css`
+    padding: 10px 20px;
+    width: 200px;
+  `)}
+`;
+
+export const shareLinkBox = css`
+  background-color: ${theme.color.gray100};
+  color: ${theme.color.gray300};
+  ${theme.font.preM14}
+  border-radius: 10px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding: 16px 18px;
+  width: 400px;
+
+  ${mobile(css`
+    width: 100%;
+    padding: 10px;
+  `)}
+`;

--- a/packages/service/src/pages/LotteryApplyInfo/LotteryApplyInfo.css.ts
+++ b/packages/service/src/pages/LotteryApplyInfo/LotteryApplyInfo.css.ts
@@ -57,7 +57,7 @@ export const btn = css`
 
 export const shareLinkBox = css`
   background-color: ${theme.color.gray100};
-  color: ${theme.color.gray300};
+  color: ${theme.color.gray500};
   ${theme.font.preM14}
   border-radius: 10px;
   white-space: nowrap;

--- a/packages/service/src/pages/LotteryApplyInfo/LotteryApplyInfo.css.ts
+++ b/packages/service/src/pages/LotteryApplyInfo/LotteryApplyInfo.css.ts
@@ -64,7 +64,7 @@ export const shareLinkBox = css`
   overflow: hidden;
   text-overflow: ellipsis;
   padding: 16px 18px;
-  width: 400px;
+  width: 500px;
 
   ${mobile(css`
     width: 100%;

--- a/packages/service/src/pages/LotteryApplyInfo/LotteryApplyInfo.tsx
+++ b/packages/service/src/pages/LotteryApplyInfo/LotteryApplyInfo.tsx
@@ -1,0 +1,93 @@
+import { useNavigate } from "react-router-dom";
+import * as style from "./LotteryApplyInfo.css";
+import { Button, ButtonVariant } from "@service/common/components/Button";
+import { ClipBoardButton } from "@service/common/components/ClipBoardButton";
+import { theme } from "@watermelon-clap/core/src/theme";
+import { Space } from "@service/common/styles/Space";
+import { css } from "@emotion/react";
+import { PARTS_COLLECTION_PAGE_ROUTE } from "@service/constants/routes";
+import { useEffect, useRef, useState } from "react";
+import { mobile } from "@service/common/responsive/responsive";
+import { useMobile } from "@service/common/hooks/useMobile";
+import { apiGetMyShareLink } from "@service/apis/link/apiGetMyShareLink";
+
+export const LotteryApplyInfo = () => {
+  const navigate = useNavigate();
+  const shareLinkRef = useRef(null);
+  const [shareLink, setShareLink] = useState<string>();
+
+  useEffect(() => {
+    apiGetMyShareLink().then(({ link }) => {
+      setShareLink(link);
+    });
+  }, []);
+
+  const isMobile = useMobile();
+
+  return (
+    <div css={style.mainBg}>
+      <h1 css={style.pageTitle}>응모 내역 확인</h1>
+      <h2 css={style.subtitle}>내 아반떼 N 뽑기 이벤트 응모 내역 입니다.</h2>
+
+      <Space size={isMobile ? 40 : 130} />
+
+      <section css={[theme.flex.center]}>
+        <div
+          css={[
+            theme.flex.column,
+            css`
+              align-items: start;
+              gap: 20px;
+            `,
+          ]}
+        >
+          <span css={style.sectionTitle}>내 컬렉션 URL</span>
+          <span>친구 링크 클릭 수 만큼 당첨 확률도 같이 올라가요! </span>
+
+          <div
+            css={[
+              theme.flex.center,
+              theme.gap.gap12,
+              mobile(css`
+                flex-direction: column;
+                width: 100%;
+                align-items: start;
+              `),
+            ]}
+          >
+            <div css={style.shareLinkBox} ref={shareLinkRef}>
+              {shareLink}
+            </div>
+            <ClipBoardButton copyRef={shareLinkRef} />
+          </div>
+
+          <div css={[theme.flex.center, theme.gap.gap24]}>
+            <span css={[theme.font.pcB28]}>남은 뽑기권</span>
+            <span css={[theme.font.pcpB82]}>32</span>
+          </div>
+        </div>
+      </section>
+
+      <Space size={120} />
+
+      <Button
+        variant={ButtonVariant.LONG}
+        css={style.btn}
+        onClick={() => navigate(PARTS_COLLECTION_PAGE_ROUTE)}
+      >
+        내 컬렉션 바로가기
+      </Button>
+    </div>
+  );
+};
+
+// const getPartsData = async () => {
+//   try {
+//     return await apiGetMyParts();
+//   } catch (error: any) {
+//     if (error.message === "403") {
+//       reLogin().then(() => refetch());
+//     }
+//     throw error;
+//   }
+// };

--- a/packages/service/src/pages/LotteryApplyInfo/LotteryApplyInfo.tsx
+++ b/packages/service/src/pages/LotteryApplyInfo/LotteryApplyInfo.tsx
@@ -29,7 +29,7 @@ export const LotteryApplyInfo = () => {
       <h1 css={style.pageTitle}>응모 내역 확인</h1>
       <h2 css={style.subtitle}>내 아반떼 N 뽑기 이벤트 응모 내역 입니다.</h2>
 
-      <Space size={isMobile ? 40 : 130} />
+      <Space size={isMobile ? 100 : 130} />
 
       <section css={[theme.flex.center]}>
         <div
@@ -39,6 +39,9 @@ export const LotteryApplyInfo = () => {
               align-items: start;
               gap: 20px;
             `,
+            mobile(css`
+              width: 80%;
+            `),
           ]}
         >
           <span css={style.sectionTitle}>내 컬렉션 URL</span>
@@ -63,7 +66,16 @@ export const LotteryApplyInfo = () => {
 
           <div css={[theme.flex.center, theme.gap.gap24]}>
             <span css={[theme.font.pcB28]}>남은 뽑기권</span>
-            <span css={[theme.font.pcpB82]}>32</span>
+            <span
+              css={[
+                theme.font.pcpB82,
+                mobile(css`
+                  font-size: 30px;
+                `),
+              ]}
+            >
+              32
+            </span>
           </div>
         </div>
       </section>

--- a/packages/service/src/pages/LotteryApplyInfo/LotteryApplyInfo.tsx
+++ b/packages/service/src/pages/LotteryApplyInfo/LotteryApplyInfo.tsx
@@ -10,16 +10,22 @@ import { useEffect, useRef, useState } from "react";
 import { mobile } from "@service/common/responsive/responsive";
 import { useMobile } from "@service/common/hooks/useMobile";
 import { apiGetMyShareLink } from "@service/apis/link/apiGetMyShareLink";
+import { apiGetPartsRemain } from "@service/apis/partsEvent";
 
 export const LotteryApplyInfo = () => {
   const navigate = useNavigate();
   const shareLinkRef = useRef(null);
   const [shareLink, setShareLink] = useState<string>();
+  const [remainChance, setRemainChance] = useState<number>();
 
   useEffect(() => {
     apiGetMyShareLink().then(({ link }) => {
       setShareLink(link);
     });
+
+    apiGetPartsRemain().then(({ remainChance }) =>
+      setRemainChance(remainChance),
+    );
   }, []);
 
   const isMobile = useMobile();
@@ -68,13 +74,13 @@ export const LotteryApplyInfo = () => {
             <span css={[theme.font.pcB28]}>남은 뽑기권</span>
             <span
               css={[
-                theme.font.pcpB82,
+                theme.font.pcB40,
                 mobile(css`
                   font-size: 30px;
                 `),
               ]}
             >
-              32
+              {remainChance}
             </span>
           </div>
         </div>

--- a/packages/service/src/pages/LotteryApplyInfo/LotteryApplyInfo.tsx
+++ b/packages/service/src/pages/LotteryApplyInfo/LotteryApplyInfo.tsx
@@ -9,9 +9,9 @@ import { PARTS_COLLECTION_PAGE_ROUTE } from "@service/constants/routes";
 import { useEffect, useRef, useState } from "react";
 import { mobile } from "@service/common/responsive/responsive";
 import { useMobile } from "@service/common/hooks/useMobile";
-import { apiGetMyShareLink } from "@service/apis/link/apiGetMyShareLink";
 import { apiGetPartsRemain } from "@service/apis/partsEvent";
 import { useAuth } from "@watermelon-clap/core/src/hooks";
+import { apiGetMyShareLink } from "@service/apis/link/apiGetMyShareLink";
 
 export const LotteryApplyInfo = () => {
   const navigate = useNavigate();
@@ -19,17 +19,12 @@ export const LotteryApplyInfo = () => {
   const [shareLink, setShareLink] = useState<string>();
   const [remainChance, setRemainChance] = useState<number>();
 
-  const { reLogin } = useAuth();
+  const { handleTokenError } = useAuth();
 
   useEffect(() => {
     apiGetMyShareLink()
       .then(({ link }) => setShareLink(link))
-      .catch((error: Error) => {
-        if (error.message === "403") {
-          reLogin().then(() => location.reload());
-        }
-        throw error;
-      });
+      .catch((error: Error) => handleTokenError(error));
 
     apiGetPartsRemain().then(({ remainChance }) =>
       setRemainChance(remainChance),

--- a/packages/service/src/pages/LotteryApplyInfo/LotteryApplyInfo.tsx
+++ b/packages/service/src/pages/LotteryApplyInfo/LotteryApplyInfo.tsx
@@ -11,6 +11,7 @@ import { mobile } from "@service/common/responsive/responsive";
 import { useMobile } from "@service/common/hooks/useMobile";
 import { apiGetMyShareLink } from "@service/apis/link/apiGetMyShareLink";
 import { apiGetPartsRemain } from "@service/apis/partsEvent";
+import { useAuth } from "@watermelon-clap/core/src/hooks";
 
 export const LotteryApplyInfo = () => {
   const navigate = useNavigate();
@@ -18,10 +19,17 @@ export const LotteryApplyInfo = () => {
   const [shareLink, setShareLink] = useState<string>();
   const [remainChance, setRemainChance] = useState<number>();
 
+  const { reLogin } = useAuth();
+
   useEffect(() => {
-    apiGetMyShareLink().then(({ link }) => {
-      setShareLink(link);
-    });
+    apiGetMyShareLink()
+      .then(({ link }) => setShareLink(link))
+      .catch((error: Error) => {
+        if (error.message === "403") {
+          reLogin().then(() => location.reload());
+        }
+        throw error;
+      });
 
     apiGetPartsRemain().then(({ remainChance }) =>
       setRemainChance(remainChance),
@@ -98,14 +106,3 @@ export const LotteryApplyInfo = () => {
     </div>
   );
 };
-
-// const getPartsData = async () => {
-//   try {
-//     return await apiGetMyParts();
-//   } catch (error: any) {
-//     if (error.message === "403") {
-//       reLogin().then(() => refetch());
-//     }
-//     throw error;
-//   }
-// };

--- a/packages/service/src/pages/LotteryApplyInfo/LotteryApplyInfo.tsx
+++ b/packages/service/src/pages/LotteryApplyInfo/LotteryApplyInfo.tsx
@@ -5,26 +5,33 @@ import { ClipBoardButton } from "@service/common/components/ClipBoardButton";
 import { theme } from "@watermelon-clap/core/src/theme";
 import { Space } from "@service/common/styles/Space";
 import { css } from "@emotion/react";
-import { PARTS_COLLECTION_PAGE_ROUTE } from "@service/constants/routes";
+import {
+  PARTS_COLLECTION_PAGE_ROUTE,
+  PICK_EVENT_PAGE_ROUTE,
+} from "@service/constants/routes";
 import { useEffect, useRef, useState } from "react";
 import { mobile } from "@service/common/responsive/responsive";
 import { useMobile } from "@service/common/hooks/useMobile";
 import { apiGetPartsRemain } from "@service/apis/partsEvent";
 import { useAuth } from "@watermelon-clap/core/src/hooks";
 import { apiGetMyShareLink } from "@service/apis/link/apiGetMyShareLink";
+import { apiGetLotteryStatus } from "@service/apis/lottery/apiGetLotteryStatus";
 
 export const LotteryApplyInfo = () => {
   const navigate = useNavigate();
   const shareLinkRef = useRef(null);
   const [shareLink, setShareLink] = useState<string>();
   const [remainChance, setRemainChance] = useState<number>();
+  const [isApplied, setIsApplied] = useState<boolean>();
 
   const { handleTokenError } = useAuth();
 
   useEffect(() => {
-    apiGetMyShareLink()
-      .then(({ link }) => setShareLink(link))
+    apiGetLotteryStatus()
+      .then(({ applied }) => setIsApplied(applied))
       .catch((error: Error) => handleTokenError(error));
+
+    apiGetMyShareLink().then(({ link }) => setShareLink(link));
 
     apiGetPartsRemain().then(({ remainChance }) =>
       setRemainChance(remainChance),
@@ -39,65 +46,92 @@ export const LotteryApplyInfo = () => {
       <h2 css={style.subtitle}>내 아반떼 N 뽑기 이벤트 응모 내역 입니다.</h2>
 
       <Space size={isMobile ? 100 : 130} />
-
-      <section css={[theme.flex.center]}>
-        <div
-          css={[
-            theme.flex.column,
-            css`
-              align-items: start;
-              gap: 20px;
-            `,
-            mobile(css`
-              width: 80%;
-            `),
-          ]}
-        >
-          <span css={style.sectionTitle}>내 컬렉션 URL</span>
-          <span>친구 링크 클릭 수 만큼 당첨 확률도 같이 올라가요! </span>
-
+      {isApplied ? (
+        <section css={[theme.flex.center]}>
           <div
             css={[
-              theme.flex.center,
-              theme.gap.gap12,
-              mobile(css`
-                flex-direction: column;
-                width: 100%;
+              theme.flex.column,
+              css`
                 align-items: start;
+                gap: 20px;
+              `,
+              mobile(css`
+                width: 80%;
               `),
             ]}
           >
-            <div css={style.shareLinkBox} ref={shareLinkRef}>
-              {shareLink}
-            </div>
-            <ClipBoardButton copyRef={shareLinkRef} />
-          </div>
+            <span css={style.sectionTitle}>내 컬렉션 URL</span>
+            <span>친구 링크 클릭 수 만큼 당첨 확률도 같이 올라가요! </span>
 
-          <div css={[theme.flex.center, theme.gap.gap24]}>
-            <span css={[theme.font.pcB28]}>남은 뽑기권</span>
-            <span
+            <div
               css={[
-                theme.font.pcB40,
+                theme.flex.center,
+                theme.gap.gap12,
                 mobile(css`
-                  font-size: 30px;
+                  flex-direction: column;
+                  width: 100%;
+                  align-items: start;
                 `),
               ]}
             >
-              {remainChance}
-            </span>
+              <div css={style.shareLinkBox} ref={shareLinkRef}>
+                {shareLink}
+              </div>
+              <ClipBoardButton copyRef={shareLinkRef} />
+            </div>
+
+            <div css={[theme.flex.center, theme.gap.gap24]}>
+              <span css={[theme.font.pcB28]}>남은 뽑기권</span>
+              <span
+                css={[
+                  theme.font.pcB40,
+                  mobile(css`
+                    font-size: 30px;
+                  `),
+                ]}
+              >
+                {remainChance}
+              </span>
+            </div>
           </div>
+        </section>
+      ) : (
+        <div
+          css={[
+            theme.font.pcB28,
+            css`
+              text-align: center;
+            `,
+            mobile(css`
+              font-size: 16px;
+              width: 90%;
+              margin: 0 auto;
+            `),
+          ]}
+        >
+          내 아반떼 N 뽑기 이벤트에 참여한 이력이 없습니다.
         </div>
-      </section>
+      )}
 
       <Space size={120} />
 
-      <Button
-        variant={ButtonVariant.LONG}
-        css={style.btn}
-        onClick={() => navigate(PARTS_COLLECTION_PAGE_ROUTE)}
-      >
-        내 컬렉션 바로가기
-      </Button>
+      {isApplied ? (
+        <Button
+          variant={ButtonVariant.LONG}
+          css={style.btn}
+          onClick={() => navigate(PARTS_COLLECTION_PAGE_ROUTE)}
+        >
+          내 컬렉션 바로가기
+        </Button>
+      ) : (
+        <Button
+          variant={ButtonVariant.LONG}
+          css={style.btn}
+          onClick={() => navigate(PICK_EVENT_PAGE_ROUTE)}
+        >
+          내 아반떼 N 뽑으러 가기
+        </Button>
+      )}
     </div>
   );
 };

--- a/packages/service/src/pages/LotteryApplyInfo/index.ts
+++ b/packages/service/src/pages/LotteryApplyInfo/index.ts
@@ -1,0 +1,1 @@
+export { LotteryApplyInfo } from "./LotteryApplyInfo";

--- a/packages/service/src/router.tsx
+++ b/packages/service/src/router.tsx
@@ -39,7 +39,7 @@ import {
   NQuizEventWinnerApply,
 } from "./pages";
 import { LotteryApplyFinish } from "./pages/LotteryApplyFinish";
-import { LotteryApplyInfo } from "./pages/LotteryApplyInfo/LotteryApplyInfo";
+import { LotteryApplyInfo } from "./pages/LotteryApplyInfo";
 
 export const router = createBrowserRouter([
   {

--- a/packages/service/src/router.tsx
+++ b/packages/service/src/router.tsx
@@ -17,6 +17,7 @@ import {
   SHARE_PAGE_ROUTE,
   N_QUIZ_EVENT_PAGE_WINNER_APLLY_PAGE_ROUTE,
   LOTTER_APPLY_FINISH_PAGE_ROUTE,
+  LOTTER_APPLY_INFO_PAGE_ROUTE,
 } from "./constants/routes";
 import { RotateDemoPage } from "./Demo/pages/RotateDemoPage";
 import { AuthDemoPage } from "./Demo/pages/AuthDemoPage";
@@ -38,6 +39,7 @@ import {
   NQuizEventWinnerApply,
 } from "./pages";
 import { LotteryApplyFinish } from "./pages/LotteryApplyFinish";
+import { LotteryApplyInfo } from "./pages/LotteryApplyInfo/LotteryApplyInfo";
 
 export const router = createBrowserRouter([
   {
@@ -58,6 +60,10 @@ export const router = createBrowserRouter([
       {
         path: LOTTER_APPLY_FINISH_PAGE_ROUTE,
         element: <LotteryApplyFinish />,
+      },
+      {
+        path: LOTTER_APPLY_INFO_PAGE_ROUTE,
+        element: <LotteryApplyInfo />,
       },
     ],
   },


### PR DESCRIPTION
# 🔗 연관된 이슈

- [연관된 이슈 링크](https://watermelon-clap.atlassian.net/browse/CLAP-142)
  
<br/>

# 📗 작업 내용

### 이슈 내용
- 유저 본인이 이벤트에 응모했는지, 응모했다면 공유링크와 남은 뽑기 횟수를 확인할 수 있는 `응모 내역 확인 페이지` 구현


### 변경 사항



#### [PC]

![image](https://github.com/user-attachments/assets/643499bc-cc1a-49f0-b3c1-36070b6324a2)

#### [Mobile]

![image](https://github.com/user-attachments/assets/023b9fc6-d5b4-43f6-96dc-622ea84cffd0)


#### [아직 응모하지 않은 유저 예외처리]

![image](https://github.com/user-attachments/assets/34aff58a-514c-4647-8e78-0b26ea6c3a6c)


<br/>


# ✏️ 리뷰어 멘션

- @DaeWon9 
