### PR TITLE
feat(CLAP-153): 퀴즈 Status 별 예외처리

### DIFF
--- a/packages/service/src/components/nQuizEvent/NQuizReward/NQuizReward.css.ts
+++ b/packages/service/src/components/nQuizEvent/NQuizReward/NQuizReward.css.ts
@@ -49,8 +49,11 @@ export const rewardContainerStyle = (status: EventStatusType) => css`
 `;
 
 export const imgStyle = css`
-  width: 80%;
-  aspect-ratio: 2 / 1;
+  width: 70%;
+
+  ${mobile(css`
+    width: 65%;
+  `)}
 `;
 
 export const nameStyle = css`

--- a/packages/service/src/components/nQuizEvent/NQuizSection/NQuizAlternativeBody/NQuizAlternativeBody.css.ts
+++ b/packages/service/src/components/nQuizEvent/NQuizSection/NQuizAlternativeBody/NQuizAlternativeBody.css.ts
@@ -1,11 +1,46 @@
 import { css } from "@emotion/react";
 import { EventStatusType } from "../../NQuizReward/type";
 import { theme } from "@watermelon-clap/core/src/theme";
+import { mobile } from "@service/common/responsive/responsive";
 
 export const alternativeBodyStyles = (status: EventStatusType) => css`
   position: absolute;
   margin: 0 auto;
+  text-align: center;
+  color: ${theme.color.gray200};
   ${theme.font.preB38}
 
-  ${(status === "OPEN" || status === "UPCOMING") && "visibility: hidden;"}
+  ${status === "OPEN" && "visibility: hidden;"};
+`;
+
+export const titleStyle = css`
+  ${theme.font.preSB}
+  font-size: 68px;
+
+  white-space: nowrap;
+  ${mobile(css`
+    font-size: 32px;
+  `)};
+`;
+
+export const contentStyle = css`
+  ${theme.font.preB}
+  font-size: 32px;
+
+  ${mobile(css`
+    font-size: 16px;
+  `)};
+`;
+
+export const hintStyle = css`
+  ${theme.font.preB}
+  color: ${theme.color.gray300};
+  opacity: 0.6;
+  padding-top: 20px;
+  font-size: 18px;
+
+  ${mobile(css`
+    padding-top: 10px;
+    font-size: 9px;
+  `)};
 `;

--- a/packages/service/src/components/nQuizEvent/NQuizSection/NQuizAlternativeBody/NQuizAlternativeBody.tsx
+++ b/packages/service/src/components/nQuizEvent/NQuizSection/NQuizAlternativeBody/NQuizAlternativeBody.tsx
@@ -1,5 +1,18 @@
+import {
+  QUIZ_ALERT_CONTENT_CLOSED,
+  QUIZ_ALERT_CONTENT_END,
+  QUIZ_ALERT_CONTENT_UPCOMMING,
+  QUIZ_ALERT_HINT,
+  QUIZ_ALERT_TITLE_FINISHED,
+  QUIZ_ALERT_TITLE_UPCOMMING,
+} from "../../../../constants/quizContents";
 import { EventStatusType } from "../../NQuizReward/type";
-import { alternativeBodyStyles } from "./NQuizAlternativeBody.css";
+import {
+  alternativeBodyStyles,
+  titleStyle,
+  contentStyle,
+  hintStyle,
+} from "./NQuizAlternativeBody.css";
 
 interface NQuizAlternativeBodyProps {
   status: EventStatusType;
@@ -7,21 +20,32 @@ interface NQuizAlternativeBodyProps {
 
 export const NQuizAlternativeBody = ({ status }: NQuizAlternativeBodyProps) => {
   let displayText;
+  let displayTitle;
 
   switch (status) {
     case "UPCOMING":
-      displayText = "퀴즈가 오픈될 예정입니다.";
+      displayText = QUIZ_ALERT_CONTENT_UPCOMMING;
+      displayTitle = QUIZ_ALERT_TITLE_UPCOMMING;
       break;
     case "CLOSED":
-      displayText = "퀴즈가 종료되었습니다.";
+      displayText = QUIZ_ALERT_CONTENT_CLOSED;
+      displayTitle = QUIZ_ALERT_TITLE_FINISHED;
       break;
     case "END":
-      displayText = "퀴즈 이벤트가 모두 종료되었습니다.";
+      displayText = QUIZ_ALERT_CONTENT_END;
+      displayTitle = QUIZ_ALERT_TITLE_FINISHED;
       break;
     default:
-      displayText = "퀴즈가 종료되었습니다.";
+      displayText = QUIZ_ALERT_CONTENT_END;
+      displayTitle = QUIZ_ALERT_TITLE_FINISHED;
       break;
   }
 
-  return <div css={alternativeBodyStyles(status)}>{displayText}</div>;
+  return (
+    <div css={alternativeBodyStyles(status)}>
+      <h1 css={titleStyle}>{displayTitle}</h1>
+      <p css={contentStyle}>{displayText}</p>
+      {status === "UPCOMING" && <p css={hintStyle}>{QUIZ_ALERT_HINT}</p>}
+    </div>
+  );
 };

--- a/packages/service/src/components/nQuizEvent/NQuizSection/NQuizInput/NQuizInput.tsx
+++ b/packages/service/src/components/nQuizEvent/NQuizSection/NQuizInput/NQuizInput.tsx
@@ -110,8 +110,13 @@ export const NQuizInput = ({ openedQuiz }: NQuizInputProps) => {
         value={inputValue}
         onChange={handleInputChange}
         onKeyPress={handleKeyDown}
+        disabled={openedQuiz.status === "OPEN" ? false : true}
       />
-      <Button css={nQuizSubmitButtonStyles} onClick={handleSubmit}>
+      <Button
+        css={nQuizSubmitButtonStyles}
+        onClick={handleSubmit}
+        disabled={openedQuiz.status === "OPEN" ? false : true}
+      >
         제출하기
       </Button>
     </div>

--- a/packages/service/src/components/nQuizEvent/NQuizSection/NQuizSection.css.ts
+++ b/packages/service/src/components/nQuizEvent/NQuizSection/NQuizSection.css.ts
@@ -3,6 +3,12 @@ import { mobile } from "@service/common/responsive/responsive";
 import { theme } from "@watermelon-clap/core/src/theme";
 import { EventStatusType } from "../NQuizReward/type";
 
+export const nQuizContainerStyle = css`
+  ${theme.flex.center}
+  width: 100%;
+  overflow: hidden;
+`;
+
 export const nQuizSectionStyles = (status: EventStatusType) => css`
   position: relative;
   ${theme.flex.center}
@@ -20,6 +26,11 @@ export const nQuizSectionStyles = (status: EventStatusType) => css`
     padding: 20px 21px;
     border-radius: 10px;
   `)}
+`;
+
+export const nQuizImageStyle = css`
+  overflow: hidden;
+  width: 80%;
 `;
 
 export const nQuizSectionHeaderContainerStyles = css`

--- a/packages/service/src/components/nQuizEvent/NQuizSection/NQuizSection.css.ts
+++ b/packages/service/src/components/nQuizEvent/NQuizSection/NQuizSection.css.ts
@@ -3,7 +3,8 @@ import { mobile } from "@service/common/responsive/responsive";
 import { theme } from "@watermelon-clap/core/src/theme";
 import { EventStatusType } from "../NQuizReward/type";
 
-export const nQuizSectionStyles = css`
+export const nQuizSectionStyles = (status: EventStatusType) => css`
+  position: relative;
   ${theme.flex.center}
   ${theme.flex.column}
   width: 100%;
@@ -12,6 +13,8 @@ export const nQuizSectionStyles = css`
   border-radius: 20px;
   background-color: ${theme.color.white};
   padding: 40px 48px;
+
+  ${status !== "OPEN" && "opacity: 0.3;"}
 
   ${mobile(css`
     padding: 20px 21px;
@@ -33,7 +36,7 @@ export const nQuizSectionBodyContainerStyles = (status: EventStatusType) => css`
   height: 86%;
   padding-top: 10px;
 
-  ${(status === "END" || status === "CLOSED") && "visibility: hidden;"}
+  ${(status === "END" || status === "UPCOMING") && "visibility: hidden;"}
 
   ${mobile(css`
     padding-top: 0;

--- a/packages/service/src/components/nQuizEvent/NQuizSection/NQuizSection.tsx
+++ b/packages/service/src/components/nQuizEvent/NQuizSection/NQuizSection.tsx
@@ -7,6 +7,8 @@ import {
   nQuizSectionHeaderContainerStyles,
   nQuizSectionBodyContainerStyles,
 } from "./NQuizSection.css";
+import { css } from "@emotion/react";
+import { theme } from "@watermelon-clap/core/src/theme";
 
 interface NQuizSectionProps {
   openedQuiz: IOrderEvent;
@@ -14,24 +16,34 @@ interface NQuizSectionProps {
 
 export const NQuizSection = ({ openedQuiz }: NQuizSectionProps) => {
   return (
-    <section css={nQuizSectionStyles}>
-      <div css={nQuizSectionHeaderContainerStyles}>
-        <NQuizHeader
-          date={openedQuiz.startDate.slice(0, 10)}
-          status={openedQuiz.status}
-        />
-      </div>
+    <div
+      css={css`
+        ${theme.flex.center}
+        width: 100%;
+        overflow: hidden;
+      `}
+    >
+      <section css={nQuizSectionStyles(openedQuiz.status)}>
+        <div css={nQuizSectionHeaderContainerStyles}>
+          <NQuizHeader
+            date={openedQuiz.startDate.slice(0, 10)}
+            status={openedQuiz.status}
+          />
+        </div>
 
-      <div css={nQuizSectionBodyContainerStyles(openedQuiz.status)}>
-        <img
-          src={openedQuiz.quiz?.imgSrc}
-          alt="N뽑기 이벤트 퀴즈 이미지"
-          width="80%"
-        />
-        <NQuizInput openedQuiz={openedQuiz} />
-      </div>
-
+        <div css={nQuizSectionBodyContainerStyles(openedQuiz.status)}>
+          <img
+            css={css`
+              overflow: hidden;
+            `}
+            src={openedQuiz.quiz?.imgSrc}
+            alt="N뽑기 이벤트 퀴즈 이미지"
+            width="80%"
+          />
+          <NQuizInput openedQuiz={openedQuiz} />
+        </div>
+      </section>
       <NQuizAlternativeBody status={openedQuiz.status} />
-    </section>
+    </div>
   );
 };

--- a/packages/service/src/components/nQuizEvent/NQuizSection/NQuizSection.tsx
+++ b/packages/service/src/components/nQuizEvent/NQuizSection/NQuizSection.tsx
@@ -6,9 +6,9 @@ import {
   nQuizSectionStyles,
   nQuizSectionHeaderContainerStyles,
   nQuizSectionBodyContainerStyles,
+  nQuizContainerStyle,
+  nQuizImageStyle,
 } from "./NQuizSection.css";
-import { css } from "@emotion/react";
-import { theme } from "@watermelon-clap/core/src/theme";
 
 interface NQuizSectionProps {
   openedQuiz: IOrderEvent;
@@ -16,13 +16,7 @@ interface NQuizSectionProps {
 
 export const NQuizSection = ({ openedQuiz }: NQuizSectionProps) => {
   return (
-    <div
-      css={css`
-        ${theme.flex.center}
-        width: 100%;
-        overflow: hidden;
-      `}
-    >
+    <div css={nQuizContainerStyle}>
       <section css={nQuizSectionStyles(openedQuiz.status)}>
         <div css={nQuizSectionHeaderContainerStyles}>
           <NQuizHeader
@@ -33,12 +27,9 @@ export const NQuizSection = ({ openedQuiz }: NQuizSectionProps) => {
 
         <div css={nQuizSectionBodyContainerStyles(openedQuiz.status)}>
           <img
-            css={css`
-              overflow: hidden;
-            `}
+            css={nQuizImageStyle}
             src={openedQuiz.quiz?.imgSrc}
             alt="N뽑기 이벤트 퀴즈 이미지"
-            width="80%"
           />
           <NQuizInput openedQuiz={openedQuiz} />
         </div>

--- a/packages/service/src/constants/quizContents.ts
+++ b/packages/service/src/constants/quizContents.ts
@@ -1,0 +1,12 @@
+export const QUIZ_ALERT_TITLE_UPCOMMING = "COMMING SOON" as const;
+export const QUIZ_ALERT_TITLE_FINISHED = "THANK YOU" as const;
+
+export const QUIZ_ALERT_CONTENT_UPCOMMING =
+  "퀴즈가 오픈될 예정입니다." as const;
+export const QUIZ_ALERT_CONTENT_CLOSED =
+  "오늘의 퀴즈가 마감되었습니다." as const;
+export const QUIZ_ALERT_CONTENT_END =
+  "퀴즈 이벤트가 모두 종료되었습니다." as const;
+
+export const QUIZ_ALERT_HINT =
+  "HINT!! AVANTE N 신차 정보 페이지를 참고해주세요!" as const;

--- a/packages/service/src/pages/NQuizEvent/NQuizEvent.tsx
+++ b/packages/service/src/pages/NQuizEvent/NQuizEvent.tsx
@@ -25,6 +25,16 @@ export const NQuizEvent = () => {
     (quiz) => quiz.status === "OPEN",
   ) as IOrderEvent;
 
+  const closedQuiz = quizList.find(
+    (quiz) => quiz.status === "CLOSED",
+  ) as IOrderEvent;
+
+  const upcomingQuiz = quizList.find(
+    (quiz) => quiz.status === "UPCOMING",
+  ) as IOrderEvent;
+
+  openedQuiz.status = "CLOSED";
+
   return (
     <>
       <div css={backgroundStyle}>
@@ -42,7 +52,15 @@ export const NQuizEvent = () => {
           ))}
         </div>
 
-        <NQuizSection openedQuiz={openedQuiz} />
+        {openedQuiz && <NQuizSection openedQuiz={openedQuiz} />}
+
+        {closedQuiz && <NQuizSection openedQuiz={closedQuiz} />}
+
+        {upcomingQuiz && <NQuizSection openedQuiz={upcomingQuiz} />}
+
+        {!openedQuiz && !closedQuiz && !upcomingQuiz && (
+          <NQuizSection openedQuiz={quizList[0]} />
+        )}
 
         <span css={termTitleStyle}>{nQuizEventTermTitle}</span>
         <ul css={termListStyle}>


### PR DESCRIPTION
# 🔗 연관된 이슈

- [연관된 이슈 링크](https://watermelon-clap.atlassian.net/browse/CLAP-153?atlOrigin=eyJpIjoiNTkyYWZkZDZjNDQzNDI1OWJiNzA5NGMwZDI5YTg2Y2MiLCJwIjoiaiJ9)
  
<br/>

# 📗 작업 내용
퀴즈의 Status별 예외처리를 추가했습니다.

### 이슈 내용
- 퀴즈의 상태는  "UPCOMING" | "OPEN" | "CLOSED" | "END" 가 존재하고 상태별로 퀴즈섹션을 다르게 보여주어야 했음
- OPEN 상태일때만 처리가 되어있어, 나머지 상태일 때, 에러바운더리로 넘어가는 이슈 발생
- 이에, 상태별 로직을 추가함


### 변경 사항
- "UPCOMING" | "CLOSED" | "END" 상태 별 예외처리 추가
- UPCOMING: 자정 ~ 이벤트 오픈 전까지 ( 오픈 예정인 이벤트가 존재 할 경우 )
- CLOSED: 이벤트 기간이 끝나지 않았지만, 인원이 마감된경우
- END: 이벤트 기간이 종료된 경우

<br/>
<img width="1728" alt="KakaoTalk_Photo_2024-08-18-14-53-15 001" src="https://github.com/user-attachments/assets/7658c97f-1d29-467f-be27-bdb76d0aad88">
<img width="1728" alt="KakaoTalk_Photo_2024-08-18-14-53-15 002" src="https://github.com/user-attachments/assets/2e4e1cb4-6d6e-44f6-bf25-02d47bd40058">
<img width="1728" alt="KakaoTalk_Photo_2024-08-18-14-53-15 003" src="https://github.com/user-attachments/assets/9210aa2f-c143-4784-a5ec-48e1491fcd94">
<img width="1728" alt="KakaoTalk_Photo_2024-08-18-14-53-15 004" src="https://github.com/user-attachments/assets/38afe90d-4da8-4e49-90d4-90deb6e67cf7">



# ✏️ 리뷰어 멘션

@thgee 