### PR TITLE
feat(CLAP-155): 메인페이지 기대평 API 구현

### DIFF
--- a/packages/service/src/apis/expectation/apiGetExpectation.ts
+++ b/packages/service/src/apis/expectation/apiGetExpectation.ts
@@ -1,0 +1,10 @@
+import { customFetch } from "@watermelon-clap/core/src/utils";
+import { IExpectation } from "./type";
+
+export const apiGetExpectation = (): Promise<IExpectation[]> => {
+  return customFetch(`${import.meta.env.VITE_BACK_BASE_URL}/expectations`)
+    .then((res) => res.json())
+    .catch((error) => {
+      throw error;
+    });
+};

--- a/packages/service/src/apis/expectation/type.ts
+++ b/packages/service/src/apis/expectation/type.ts
@@ -1,0 +1,7 @@
+export interface IExpectation {
+  uploadDate: string;
+  uid: string;
+  expectation: string;
+  expectationId: string;
+  approved: boolean;
+}

--- a/packages/service/src/common/components/Marquee/Marquee.css.ts
+++ b/packages/service/src/common/components/Marquee/Marquee.css.ts
@@ -1,4 +1,5 @@
 import { css, keyframes } from "@emotion/react";
+import { mobile } from "@service/common/responsive/responsive";
 
 interface MarqueeStylesProps {
   pauseOnHover: boolean;
@@ -9,10 +10,19 @@ interface MarqueeStylesProps {
 
 const marqueeAnimation = keyframes`
   0% {
-    transform: translateX(100vw);
+    transform: translateX(-100vw);
   }
   100% {
-    transform: translateX(-200vw);
+    transform: translateX(-300vw);
+  }
+`;
+
+const mobileMarqueeAnimation = keyframes`
+  0% {
+    transform: translateX(-100vw);
+  }
+  100% {
+    transform: translateX(-700vw);
   }
 `;
 
@@ -21,6 +31,9 @@ export const marqueeItemStyles = css`
   flex-shrink: 0;
   justify-content: space-around;
   animation: ${marqueeAnimation} var(--duration) linear infinite;
+  ${mobile(css`
+    animation: ${mobileMarqueeAnimation} var(--duration) linear infinite;
+  `)}
   animation-direction: var(--direction);
   animation-play-state: running;
 `;
@@ -33,7 +46,7 @@ export const marqueeStyles = ({
 }: MarqueeStylesProps) => css`
   display: flex;
   overflow: hidden;
-  padding: 2rem;
+  padding: 20px 2rem;
   gap: ${gap};
   --duration: ${duration};
   --direction: ${reverse ? "reverse" : "normal"};

--- a/packages/service/src/common/components/Marquee/Marquee.tsx
+++ b/packages/service/src/common/components/Marquee/Marquee.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, ReactElement, Children } from "react";
+import { ReactNode, ReactElement } from "react";
 import { marqueeStyles, marqueeItemStyles } from "./Marquee.css";
 import { toPx, toS } from "@service/common/utils/formatter";
 
@@ -31,8 +31,8 @@ const Marquee = ({
   const formattedDuration = toS(duration);
   const formattedGap = toPx(gap);
 
-  const repeatedChildren = Children.toArray(children).flatMap((child) =>
-    Array(repeat).fill(child),
+  const repeatedChildren = Array.from({ length: repeat }).flatMap(
+    () => children,
   );
 
   return (

--- a/packages/service/src/components/main/Expectation/Expectations.tsx
+++ b/packages/service/src/components/main/Expectation/Expectations.tsx
@@ -1,14 +1,22 @@
 import { Marquee } from "@service/common/components/Marquee";
 import * as style from "./Expectations.css";
+import { apiGetExpectation } from "@service/apis/expectation/apiGetExpectation";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { IExpectation } from "@service/apis/expectation/type";
 
 export const Expectations = () => {
+  const { data: reviews } = useSuspenseQuery<IExpectation[]>({
+    queryKey: ["orderEvent"],
+    queryFn: () => apiGetExpectation(),
+  });
+
   return (
     <div css={style.container}>
       <Marquee pauseOnHover>
         {reviews.map((review) => (
-          <Marquee.Item>
+          <Marquee.Item key={review.expectationId}>
             <div css={style.expectationCard}>
-              <pre className="text">{review}</pre>
+              <pre className="text">{review.expectation}</pre>
             </div>
           </Marquee.Item>
         ))}
@@ -16,13 +24,3 @@ export const Expectations = () => {
     </div>
   );
 };
-
-const reviews = [
-  `강력한 성능과 민첩한 핸들링이라니~
-아반떼 N을 타면 즐거운 드라이빙을 할 수 있을 것 같아요!`,
-  `아반떼 N! 스포티한 자동차를 눈여겨보고 있었는데
-딱 제 취향이에요! 도로에서 자주 보고싶어요~`,
-  `아반떼N 너무 예뻐요! 출시되길 기다리고 있었어요
-일상형 스포츠카 기대 중입니다 ㅎㅎㅎ`,
-  `짧은 기대평`,
-];

--- a/packages/service/src/pages/NQuizEvent/NQuizEvent.tsx
+++ b/packages/service/src/pages/NQuizEvent/NQuizEvent.tsx
@@ -33,8 +33,6 @@ export const NQuizEvent = () => {
     (quiz) => quiz.status === "UPCOMING",
   ) as IOrderEvent;
 
-  openedQuiz.status = "CLOSED";
-
   return (
     <>
       <div css={backgroundStyle}>


### PR DESCRIPTION
# 🔗 연관된 이슈

- [연관된 이슈 링크](https://watermelon-clap.atlassian.net/browse/CLAP-155?atlOrigin=eyJpIjoiYjFiMThmZTdjOTFjNGFlZWJkMTBjNDk3ODA0N2UyZjQiLCJwIjoiaiJ9)
  
<br/>

# 📗 작업 내용
기대평 데이터를 서버에서 받아오고, 마퀴 애니메이션 수정


### 변경 사항
- 기대평 데이터를 서버에서 받아와서 적용
- 마퀴 애니메이션 수정: 시작 시 화면에 바로 보이기 및 끊김현상 개선 

<br/>


# ✏️ 리뷰어 멘션
@thgee 
