### PR TITLE
hotfix: 리워드 이미지 비율 수정, 기대평 쿼리키 중복 수정, 대체 퀴즈 노출 수정

### DIFF
--- a/packages/service/src/components/main/Expectation/Expectations.tsx
+++ b/packages/service/src/components/main/Expectation/Expectations.tsx
@@ -6,7 +6,7 @@ import { IExpectation } from "@service/apis/expectation/type";
 
 export const Expectations = () => {
   const { data: reviews } = useSuspenseQuery<IExpectation[]>({
-    queryKey: ["orderEvent"],
+    queryKey: ["reviews"],
     queryFn: () => apiGetExpectation(),
   });
 

--- a/packages/service/src/components/nQuizEvent/NQuizReward/NQuizReward.css.ts
+++ b/packages/service/src/components/nQuizEvent/NQuizReward/NQuizReward.css.ts
@@ -50,6 +50,8 @@ export const rewardContainerStyle = (status: EventStatusType) => css`
 
 export const imgStyle = css`
   width: 70%;
+  aspect-ratio: 1 / 1;
+  object-fit: contain;
 
   ${mobile(css`
     width: 65%;

--- a/packages/service/src/pages/NQuizEvent/NQuizEvent.tsx
+++ b/packages/service/src/pages/NQuizEvent/NQuizEvent.tsx
@@ -52,9 +52,11 @@ export const NQuizEvent = () => {
 
         {openedQuiz && <NQuizSection openedQuiz={openedQuiz} />}
 
-        {closedQuiz && <NQuizSection openedQuiz={closedQuiz} />}
+        {!openedQuiz && closedQuiz && <NQuizSection openedQuiz={closedQuiz} />}
 
-        {upcomingQuiz && <NQuizSection openedQuiz={upcomingQuiz} />}
+        {!openedQuiz && upcomingQuiz && (
+          <NQuizSection openedQuiz={upcomingQuiz} />
+        )}
 
         {!openedQuiz && !closedQuiz && !upcomingQuiz && (
           <NQuizSection openedQuiz={quizList[0]} />


### PR DESCRIPTION
# 📗 작업 내용
- 리워드 이미지의 비율 수정
- 기대평의 쿼리키가 중복되어있던 이슈 해결
- 퀴즈에서 오픈된 퀴즈가 있음에도, 오픈예정 퀴즈가 노출되던 이슈 해결

<br/>


# ✏️ 리뷰어 멘션
@thgee 
