### PR TITLE
feat(CLAP-157): 파츠페이지 레이아웃 수정

### DIFF
--- a/packages/service/src/components/partsCollection/CustomCard/CustomCard.css.ts
+++ b/packages/service/src/components/partsCollection/CustomCard/CustomCard.css.ts
@@ -8,9 +8,12 @@ export const card = css`
   background-color: white;
   margin: 0 auto;
   position: relative;
+  flex-shrink: 0;
+  margin-top: 60px;
 
   ${mobile(css`
-    width: 400px;
+    width: 350px;
+    margin: 0 auto;
   `)}
 `;
 
@@ -24,7 +27,7 @@ export const bgImg = css`
   height: 100%;
 
   ${mobile(css`
-    width: 400px;
+    width: 350px;
   `)}
 `;
 
@@ -38,7 +41,7 @@ export const carImg = css`
   transform: translate(-50%, -50%);
 
   ${mobile(css`
-    width: 450px;
+    width: 350px;
   `)}
 `;
 
@@ -52,7 +55,7 @@ export const colorImg = css`
   transform: translate(-50%, -50%);
 
   ${mobile(css`
-    width: 450px;
+    width: 350px;
   `)}
 `;
 
@@ -65,9 +68,9 @@ export const wheelImg = css`
   left: 305px;
 
   ${mobile(css`
-    bottom: 45px;
-    left: 170px;
-    width: 161px;
+    bottom: 47px;
+    left: 153px;
+    width: 123px;
   `)}
 `;
 
@@ -79,8 +82,8 @@ export const spoilerImg = css`
   right: 118px;
 
   ${mobile(css`
-    width: 30px;
-    top: 78px;
-    right: 53px;
+    width: 26.7px;
+    top: 72px;
+    right: 57.1px;
   `)}
 `;

--- a/packages/service/src/components/partsCollection/PartsTab/PartsCard/PartsCard.css.ts
+++ b/packages/service/src/components/partsCollection/PartsTab/PartsCard/PartsCard.css.ts
@@ -4,11 +4,11 @@ import { theme } from "@watermelon-clap/core/src/theme";
 
 export const container = css`
   ${theme.flex.column}
-  width : 48%;
+  width : 31.2%;
   cursor: pointer;
 
   ${mobile(css`
-    width: 100%;
+    width: 46%;
   `)}
 `;
 
@@ -19,30 +19,66 @@ export const card = (equipped: boolean) => css`
   position: relative;
   background-color: ${theme.color.white};
   ${theme.flex.center};
+  ${mobile(css`
+    border-radius: 10px;
+  `)}
+
+  &::before {
+    visibility: ${!equipped ? "visible" : "hidden"};
+    content: "";
+    display: block;
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+  }
 
   &::after {
-    visibility: ${equipped ? "hidden" : "visible"};
-    content: "미장착";
+    visibility: ${equipped ? "visible" : "hidden"};
+    content: "장착중";
     display: inline-flex;
     justify-content: center;
     align-items: center;
     position: absolute;
     color: ${theme.color.white};
     ${theme.font.preB24}
+    font-size: 16px;
+    background-color: ${theme.color.eventBlue};
+    padding: 10px 20px;
+    animation: fadeInOut 1s infinite alternate;
 
-    width: 100%;
-    height: 100%;
-    background-color: rgba(0, 0, 0, 0.6);
+    width: 80%;
+    height: 5%;
+    bottom: 0;
+
+    ${mobile(css`
+      font-size: 14px;
+    `)}
+  }
+
+  @keyframes fadeInOut {
+    0% {
+      opacity: 0.6;
+    }
+    100% {
+      opacity: 1;
+    }
   }
 `;
 
 export const img = (cate: string) => css`
   width: 100%;
   width: ${(cate === "REAR" || cate === "WHEEL") && "80%"};
+  height: ${cate === "REAR" && "80%"};
 `;
 
 export const name = css`
-  ${theme.font.preB24};
+  ${theme.font.preB16};
   color: ${theme.color.white};
   margin-top: 20px;
+
+  ${mobile(css`
+    font-size: 14px;
+    margin-top: 10px;
+  `)}
 `;

--- a/packages/service/src/components/partsCollection/PartsTab/PartsTab.css.ts
+++ b/packages/service/src/components/partsCollection/PartsTab/PartsTab.css.ts
@@ -6,18 +6,19 @@ export const container = css`
   ${theme.flex.column}
   margin: 0 auto;
 `;
+
 export const tabWrap = css`
   display: flex;
   justify-content: space-between;
   margin: 0 auto;
-  margin-top: 80px;
   width: 700px;
 
   ${mobile(css`
-    width: 100%;
-    flex-wrap: wrap;
-
-    justify-content: space-around;
+    width: 80vw;
+    gap: 10px;
+    align-items: center;
+    justify-content: center;
+    margin-top: 20px;
   `)}
 `;
 
@@ -35,19 +36,33 @@ export const tabBtn = (isSelected: boolean) => css`
   outline: none;
 
   ${mobile(css`
-    margin: 10px 8%;
+    border: ${isSelected ? `1px solid ${theme.color.white}` : `none`};
+    width: fit-content;
+    height: fit-content;
+    border-radius: 10px;
+    padding: 6px 12px;
+    font-size: 14px;
   `)}
 `;
 
 export const partsCardWrap = css`
-  ${theme.flex.between}
-  gap: 80px 20px;
+  display: flex;
+  align-items: baseline;
+  justify-content: flex-start;
+
+  gap: 20px 20px;
   flex-wrap: wrap;
-  width: 90%;
-  max-width: 1000px;
+  width: 700px;
   margin-top: 30px;
+  height: 540px;
+  border: 2px solid ${theme.color.gray200};
+  padding: 20px;
+  border-radius: 16px;
 
   ${mobile(css`
-    justify-content: center;
+    border: none;
+    padding: 0;
+    max-width: 350px;
+    height: fit-content;
   `)}
 `;

--- a/packages/service/src/pages/PartsCollection/PartsCollection.css.ts
+++ b/packages/service/src/pages/PartsCollection/PartsCollection.css.ts
@@ -5,18 +5,33 @@ import { theme } from "@watermelon-clap/core/src/theme";
 export const mainBg = css`
   background-image: url("/images/common/main-bg.webp");
   background-size: cover;
-  padding-bottom: 200px;
+  padding: 0 5%;
+  padding-bottom: 100px;
+
+  ${mobile(css`
+    min-height: 100vh;
+  `)}
 `;
 
 export const pageTitle = css`
   text-align: center;
   ${theme.font.pcpB}
-  font-size : calc(50px + 2vw);
-  padding: 100px;
+  font-size : calc(40px + 1vw);
+  padding: 100px 0;
   color: ${theme.color.white};
 
   ${mobile(css`
     font-size: calc(20px + 2vw);
     padding: 100px 0 50px 0;
   `)}
+`;
+
+export const partsContainer = css`
+  ${theme.flex.center}
+  flex-wrap: wrap;
+  gap: 40px;
+
+  ${mobile(css`
+    display: block;
+  `)};
 `;

--- a/packages/service/src/pages/PartsCollection/PartsCollection.tsx
+++ b/packages/service/src/pages/PartsCollection/PartsCollection.tsx
@@ -36,8 +36,11 @@ export const PartsCollection = () => {
   return (
     <div css={style.mainBg}>
       <h1 css={style.pageTitle}>내 아반떼 N 파츠 컬렉션</h1>
-      <CustomCard {...equippedPartsImg} />
-      <PartsTab partsDatas={partsDatas} refetchGetMyParts={refetch} />
+      <div css={style.partsContainer}>
+        <CustomCard {...equippedPartsImg} />
+
+        <PartsTab partsDatas={partsDatas} refetchGetMyParts={refetch} />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
# 🔗 연관된 이슈

- [연관된 이슈 링크](https://watermelon-clap.atlassian.net/browse/CLAP-157?atlOrigin=eyJpIjoiYmZjY2IwNjBlZTcwNDM4NDg3ZDkzZjk5MjExOTJjYjYiLCJwIjoiaiJ9)
  
<br/>

# 📗 작업 내용
파츠 컬렉션 페이지에서 UX/UI 쪽으로 피드백이 들어와 반영

### 변경 사항
- 레이아웃 변경
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/9fc6e822-d38d-4868-b031-e01bd9dda663">

<img width="392" alt="image" src="https://github.com/user-attachments/assets/8f755df8-cf5d-4c1d-8834-528120042cc5">


<br/>


# ✏️ 리뷰어 멘션
- @thgee 