### PR TITLE
feat(CLAP-153): 어드민 로그인 처리 추가

### DIFF
--- a/packages/admin/src/App.tsx
+++ b/packages/admin/src/App.tsx
@@ -1,11 +1,13 @@
 import { Outlet } from "react-router-dom";
 import { GlobalNavigationBar } from "./common/components/GlobalNavigationBar";
+import { ErrorBoundary } from "react-error-boundary";
+import { Error } from "./pages/Error";
 
 export const App = () => {
   return (
-    <div>
+    <ErrorBoundary FallbackComponent={Error}>
       <GlobalNavigationBar />
       <Outlet />
-    </div>
+    </ErrorBoundary>
   );
 };

--- a/packages/admin/src/apis/auth/apiGetAdminAuth.ts
+++ b/packages/admin/src/apis/auth/apiGetAdminAuth.ts
@@ -1,0 +1,14 @@
+import { customFetch } from "@watermelon-clap/core/src/utils";
+import { getAccessToken } from "@watermelon-clap/core/src/utils";
+
+export const apiGetAdminAuth = async (): Promise<void> => {
+  const url = `${import.meta.env.VITE_BACK_BASE_URL}/admin/check`;
+
+  return customFetch(url, {
+    headers: {
+      Authorization: `Bearer ${getAccessToken()}`,
+    },
+  }).catch((error) => {
+    throw error;
+  });
+};

--- a/packages/admin/src/common/components/GlobalNavigationBar/GlobalNavigationBar.tsx
+++ b/packages/admin/src/common/components/GlobalNavigationBar/GlobalNavigationBar.tsx
@@ -14,6 +14,8 @@ import {
 } from "@admin/constants/routes";
 import { theme } from "@watermelon-clap/core/src/theme";
 import { css } from "@emotion/react";
+import { apiGetAdminAuth } from "@admin/apis/auth/apiGetAdminAuth";
+import { useErrorBoundary } from "react-error-boundary";
 
 export const GlobalNavigationBar = () => {
   const navigate = useNavigate();
@@ -21,6 +23,7 @@ export const GlobalNavigationBar = () => {
   const [selectedCategory, setSelectedCategory] = useState<"order" | "parts">(
     "order",
   );
+  const { showBoundary } = useErrorBoundary();
 
   useEffect(() => {
     if (location.pathname.includes("order")) {
@@ -29,6 +32,12 @@ export const GlobalNavigationBar = () => {
       setSelectedCategory("parts");
     }
   }, [location]);
+
+  useEffect(() => {
+    apiGetAdminAuth().catch((error) => {
+      showBoundary(error);
+    });
+  }, [location, selectedCategory]);
 
   return (
     <header css={headerContainerStyles}>

--- a/packages/admin/src/pages/Error/Error.css.ts
+++ b/packages/admin/src/pages/Error/Error.css.ts
@@ -1,0 +1,18 @@
+import { css } from "@emotion/react";
+import { theme } from "@watermelon-clap/core/src/theme";
+
+export const containerStyle = css`
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  padding: 30px 25%;
+  gap: 10px;
+`;
+
+export const errorMessageStyle = css`
+  ${theme.font.preB24}
+  color: ${theme.color.black};
+`;

--- a/packages/admin/src/pages/Error/Error.tsx
+++ b/packages/admin/src/pages/Error/Error.tsx
@@ -1,0 +1,61 @@
+import { Button } from "@admin/common/components/Button";
+import { FallbackProps } from "react-error-boundary";
+import { theme } from "@watermelon-clap/core/src/theme";
+import { useNavigate } from "react-router-dom";
+import { useErrorBoundary } from "react-error-boundary";
+import { containerStyle, errorMessageStyle } from "./Error.css";
+import { useAuth } from "@watermelon-clap/core/src/hooks";
+
+export const Error = ({ error, resetErrorBoundary }: FallbackProps) => {
+  const navigate = useNavigate();
+  const { resetBoundary } = useErrorBoundary();
+  const { login } = useAuth();
+  let errorMessage;
+
+  switch (error.message) {
+    case "403":
+      errorMessage = "접근 금지: 이 리소스에 접근할 권한이 없습니다.";
+      break;
+    case "404":
+      errorMessage =
+        "페이지를 찾을 수 없습니다: 요청하신 리소스를 찾을 수 없습니다.";
+      break;
+    case "400":
+      errorMessage =
+        "잘못된 요청: 요청이 이해되지 않거나 필요한 매개변수가 누락되었습니다.";
+      break;
+    case "500":
+      errorMessage = "서버 오류: 잠시 후 다시 시도해 주세요.";
+      break;
+    default:
+      errorMessage = "예기치 못한 오류가 발생했습니다.";
+  }
+
+  const handleHomeRedirect = () => {
+    navigate("/");
+    resetBoundary();
+  };
+
+  const handleLogin = () => {
+    login().then(() => resetBoundary());
+  };
+
+  return error.message === "403" ? (
+    <>
+      <div css={containerStyle}>
+        <pre css={errorMessageStyle}>관리자 권한이 없습니다.</pre>
+        <Button onClick={handleLogin}>로그인</Button>
+      </div>
+    </>
+  ) : (
+    <>
+      <div role="alert" css={containerStyle}>
+        <pre css={errorMessageStyle}>{errorMessage}</pre>
+        <div css={[theme.flex.center, theme.gap.gap24]}>
+          <Button onClick={handleHomeRedirect}>홈으로</Button>
+          <Button onClick={resetErrorBoundary}>다시 시도</Button>
+        </div>
+      </div>
+    </>
+  );
+};

--- a/packages/admin/src/pages/Error/index.ts
+++ b/packages/admin/src/pages/Error/index.ts
@@ -1,0 +1,1 @@
+export { Error } from "./Error";

--- a/packages/admin/src/router.tsx
+++ b/packages/admin/src/router.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter } from "react-router-dom";
+import { createBrowserRouter, Navigate } from "react-router-dom";
 import { App } from "./App";
 import {
   OrderEventManagement,
@@ -26,6 +26,10 @@ export const router = createBrowserRouter([
     element: <App />,
     children: [
       /* Order Event */
+      {
+        path: "/",
+        element: <Navigate to={ORDER_EVENT_MANAGEMENT_PAGE_ROUTE} replace />,
+      },
       {
         path: ORDER_EVENT_MANAGEMENT_PAGE_ROUTE,
         element: <OrderEventManagement />,


### PR DESCRIPTION
# 🔗 연관된 이슈

- [연관된 이슈 링크](https://watermelon-clap.atlassian.net/browse/CLAP-153?atlOrigin=eyJpIjoiZDVjNjdhMGRkYzBhNDY4YmIzYzI3MTdhMTcwMTgzOWMiLCJwIjoiaiJ9)
  
<br/>

# 📗 작업 내용
어드민 페이지에 접근 할 경우, 권한 체크를 우선적으로 하고 권한이 없을경우
발생하는 에러를 에러바운더리에서 처리하도록 함

### 이슈 내용
어드민 권한이 없는 유저에게 어드민 페이지가 노출되는 이슈


### 변경 사항
- 에러바운더리 구성
- 어드민 권한을 체크하는 API 구현
- 어드민 권한이 없다는 에러 캐치 후 로그인을 유도하는 페이지로 이동

<br/>


# ✏️ 리뷰어 멘션
@thgee 
