### PR TITLE
feat(CLAP-149): 메인페이지 이벤트바로가기 버튼 클릭 시 스크롤 이동

### DIFF
--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -20,6 +20,7 @@
     "@tsparticles/react": "^3.0.0",
     "@tsparticles/slim": "^3.5.0",
     "@types/canvas-confetti": "^1.6.4",
+    "@types/react-scroll": "^1.8.10",
     "@types/three": "^0.166.0",
     "@watermelon-clap/core": "workspace:*",
     "canvas-confetti": "^1.9.3",

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -33,6 +33,7 @@
     "react-icons": "^5.3.0",
     "react-responsive": "^10.0.0",
     "react-router-dom": "^6.24.1",
+    "react-scroll": "^1.9.0",
     "react-slick": "^0.30.2",
     "slick-carousel": "^1.8.1",
     "three": "^0.166.1",

--- a/packages/service/src/components/main/Banner/Banner.tsx
+++ b/packages/service/src/components/main/Banner/Banner.tsx
@@ -6,6 +6,7 @@ import * as style from "./Banner.css";
 import { mobile } from "@service/common/responsive/responsive";
 import { useNavigate } from "react-router-dom";
 import { NEW_CAR_PAGE_ROUTE } from "@service/constants/routes";
+import { scroller } from "react-scroll";
 
 const bannerImgs = [
   "images/main/main-banner-1.webp",
@@ -58,6 +59,14 @@ export const Banner = () => {
     };
   }, [handleResize]);
 
+  const handleClickToMoveScroll = () => {
+    scroller.scrollTo("scrollMove", {
+      duration: 700,
+      smooth: true,
+      offset: -50,
+    });
+  };
+
   return (
     <section css={style.container}>
       <div ref={bannerDivRef}>
@@ -105,7 +114,12 @@ export const Banner = () => {
           >
             자세히 보기
           </Button>
-          <Button variant={ButtonVariant.SMALL_LIGHT}>이벤트 바로 가기</Button>
+          <Button
+            variant={ButtonVariant.SMALL_LIGHT}
+            onClick={handleClickToMoveScroll}
+          >
+            이벤트 바로 가기
+          </Button>
         </div>
       </div>
     </section>

--- a/packages/service/src/pages/Main/Main.tsx
+++ b/packages/service/src/pages/Main/Main.tsx
@@ -16,7 +16,7 @@ export const Main = () => {
         <Space size={isMobile ? 30 : 100} />
         <Expectations />
         <Space size={isMobile ? 30 : 120} />
-        <div css={style.eventCardWrap}>
+        <div id="scrollMove" css={style.eventCardWrap}>
           {eventData.map((data) => (
             <EventCard eventData={data} key={data.id} />
           ))}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,6 +227,9 @@ importers:
       '@types/canvas-confetti':
         specifier: ^1.6.4
         version: 1.6.4
+      '@types/react-scroll':
+        specifier: ^1.8.10
+        version: 1.8.10
       '@types/three':
         specifier: ^0.166.0
         version: 0.166.0
@@ -1835,6 +1838,9 @@ packages:
 
   '@types/react-reconciler@0.28.8':
     resolution: {integrity: sha512-SN9c4kxXZonFhbX4hJrZy37yw9e7EIxcpHCxQv5JUS18wDE5ovkQKlqQEkufdJCCMfuI9BnjUJvhYeJ9x5Ra7g==}
+
+  '@types/react-scroll@1.8.10':
+    resolution: {integrity: sha512-RD4Z7grbdNGOKwKnUBKar6zNxqaW3n8m9QSrfvljW+gmkj1GArb8AFBomVr6xMOgHPD3v1uV3BrIf01py57daQ==}
 
   '@types/react-slick@0.23.13':
     resolution: {integrity: sha512-bNZfDhe/L8t5OQzIyhrRhBr/61pfBcWaYJoq6UDqFtv5LMwfg4NsVDD2J8N01JqdAdxLjOt66OZEp6PX+dGs/A==}
@@ -5108,6 +5114,10 @@ snapshots:
       '@types/react': 18.3.3
 
   '@types/react-reconciler@0.28.8':
+    dependencies:
+      '@types/react': 18.3.3
+
+  '@types/react-scroll@1.8.10':
     dependencies:
       '@types/react': 18.3.3
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -266,6 +266,9 @@ importers:
       react-router-dom:
         specifier: ^6.24.1
         version: 6.24.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-scroll:
+        specifier: ^1.9.0
+        version: 1.9.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-slick:
         specifier: ^0.30.2
         version: 0.30.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2695,6 +2698,9 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  lodash.throttle@4.1.1:
+    resolution: {integrity: sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==}
+
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
@@ -2974,6 +2980,12 @@ packages:
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
+
+  react-scroll@1.9.0:
+    resolution: {integrity: sha512-mamNcaX9Ng+JeSbBu97nWwRhYvL2oba+xR2GxvyXsbDeGP+gkYIKZ+aDMMj/n20TbV9SCWm/H7nyuNTSiXA6yA==}
+    peerDependencies:
+      react: ^15.5.4 || ^16.0.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^15.5.4 || ^16.0.0 || ^17.0.0 || ^18.0.0
 
   react-slick@0.30.2:
     resolution: {integrity: sha512-XvQJi7mRHuiU3b9irsqS9SGIgftIfdV5/tNcURTb5LdIokRA5kIIx3l4rlq2XYHfxcSntXapoRg/GxaVOM1yfg==}
@@ -6025,6 +6037,8 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
+  lodash.throttle@4.1.1: {}
+
   lodash@4.17.21: {}
 
   long@5.2.3: {}
@@ -6309,6 +6323,13 @@ snapshots:
     dependencies:
       '@remix-run/router': 1.17.1
       react: 18.3.1
+
+  react-scroll@1.9.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      lodash.throttle: 4.1.1
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   react-slick@0.30.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:


### PR DESCRIPTION
# 🔗 연관된 이슈

- [연관된 이슈 링크](https://watermelon-clap.atlassian.net/browse/CLAP-149)
  
<br/>

# 📗 작업 내용

### 이슈 내용
- `이벤트바로가기` 버튼 클릭 시 이벤트 카드로 스크롤이 이동합니다.


### 변경 사항


https://github.com/user-attachments/assets/9a2624cb-b0ae-489a-aa42-0d561a13b5bf


<br/>


# ✏️ 리뷰어 멘션

- @DaeWon9 
