### PR TITLE
feat: 페이지 이동 시 스크롤 상단 고정

### DIFF
--- a/packages/service/src/App.tsx
+++ b/packages/service/src/App.tsx
@@ -5,6 +5,7 @@ import { Error } from "./pages/Error";
 import { Loading } from "./pages/Loading";
 import { Suspense } from "react";
 import { ErrorBoundary } from "react-error-boundary";
+import { ScrollToTop } from "./common/components/ScrollToTop";
 
 export const App = () => {
   return (
@@ -12,6 +13,7 @@ export const App = () => {
       <ErrorBoundary FallbackComponent={Error}>
         <GlobalNavigationBar />
         <Suspense fallback={<Loading />}>
+          <ScrollToTop />
           <Outlet />
         </Suspense>
       </ErrorBoundary>

--- a/packages/service/src/common/components/ScrollToTop/ScrollToTop.tsx
+++ b/packages/service/src/common/components/ScrollToTop/ScrollToTop.tsx
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return <></>;
+};

--- a/packages/service/src/common/components/ScrollToTop/index.ts
+++ b/packages/service/src/common/components/ScrollToTop/index.ts
@@ -1,0 +1,1 @@
+export * from "./ScrollToTop";

--- a/packages/service/src/index.tsx
+++ b/packages/service/src/index.tsx
@@ -5,7 +5,6 @@ import { router } from "./router.tsx";
 import { RouterProvider } from "react-router-dom";
 import { ModalProvider } from "@watermelon-clap/core/src/providers";
 import { globalStyles } from "@watermelon-clap/core/src/theme";
-
 import { ModalContainer } from "./common/components/ModalContainer";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";


### PR DESCRIPTION
# 🔗 연관된 이슈

- [연관된 이슈 링크](https://watermelon-clap.atlassian.net/browse/CLAP-150)
  
<br/>

# 📗 작업 내용

### 이슈 내용
- 페이지 이동 시 스크롤이 상단으로 이동하지 않아 UX가 좋지 않았던 점 개선


### 변경 사항


https://github.com/user-attachments/assets/5715ac61-8051-4e1e-945f-80c1a8d9b5ae


<br/>


# ✏️ 리뷰어 멘션

- @DaeWon9 
