### PR TITLE
feat(CLAP-158): 선착순 퀴즈 당첨자 입력폼 수정

### DIFF
--- a/packages/service/src/apis/orderEvent/apiPostOrderEventApply.ts
+++ b/packages/service/src/apis/orderEvent/apiPostOrderEventApply.ts
@@ -1,4 +1,3 @@
-import { customFetch } from "@watermelon-clap/core/src/utils";
 import { IPostOrderEventApplyRequest } from "./type";
 
 export const apiPostOrderEventApply = async ({
@@ -7,7 +6,7 @@ export const apiPostOrderEventApply = async ({
   phoneNumber,
   appplyTicket,
 }: IPostOrderEventApplyRequest): Promise<Response> => {
-  return customFetch(
+  return fetch(
     `${import.meta.env.VITE_BACK_BASE_URL}/event/order/${eventId}/${quizId}/apply`,
     {
       method: "POST",

--- a/packages/service/src/common/components/Button/Button.css.ts
+++ b/packages/service/src/common/components/Button/Button.css.ts
@@ -43,7 +43,7 @@ export const shortButtonStyle = css`
     color: ${theme.color.gray300};
   }
   &:disabled {
-    background: ${theme.color.gray500};
+    background: ${theme.color.gray300};
     pointer-events: none;
   }
 `;

--- a/packages/service/src/common/components/CheckBox/CheckBox.css.ts
+++ b/packages/service/src/common/components/CheckBox/CheckBox.css.ts
@@ -1,8 +1,10 @@
 import { css } from "@emotion/react";
+import { mobile } from "@service/common/responsive/responsive";
 import { theme } from "@watermelon-clap/core/src/theme";
 
 export const checkBoxContainerStyle = css`
-  ${theme.flex.center}
+  display: flex;
+  align-items: center;
 `;
 
 export const checkBoxButtonStyle = css`
@@ -29,6 +31,11 @@ export const checkBoxStyle = (isChecked: boolean) => {
     cursor: pointer;
     background-color: ${isChecked ? white : "transparent"};
     border-color: ${isChecked ? white : gray300};
+
+    ${mobile(css`
+      height: 20px;
+      width: 20px;
+    `)}
   `;
 };
 
@@ -45,4 +52,8 @@ export const checkBoxLabelStyle = css`
   color: ${theme.color.gray300};
   margin-left: 8px;
   transition: color 0.3s ease-out;
+
+  ${mobile(css`
+    font-size: 14px;
+  `)}
 `;

--- a/packages/service/src/common/components/ModalContainer/content/modalContent.tsx
+++ b/packages/service/src/common/components/ModalContainer/content/modalContent.tsx
@@ -47,3 +47,10 @@ export const MODAL_CONTENT_ORDER_EVENT_APPLY_SUCCESS = (
     <p>경품은 추후 문자를 통해 발송됩니다.</p>
   </div>
 );
+
+export const MODAL_CONTENT_ORDER_EVENT_APPLY_DUPPLICATION = (
+  <div css={[theme.flex.center, theme.flex.column]}>
+    <p>이미 신청이 완료된 번호입니다.</p>
+    <p>하루에 한 번 참여가 가능합니다.</p>
+  </div>
+);

--- a/packages/service/src/common/components/ModalContainer/content/modalContent.tsx
+++ b/packages/service/src/common/components/ModalContainer/content/modalContent.tsx
@@ -50,7 +50,7 @@ export const MODAL_CONTENT_ORDER_EVENT_APPLY_SUCCESS = (
 
 export const MODAL_CONTENT_ORDER_EVENT_APPLY_DUPPLICATION = (
   <div css={[theme.flex.center, theme.flex.column]}>
-    <p>이미 신청이 완료된 번호입니다.</p>
-    <p>하루에 한 번 참여가 가능합니다.</p>
+    <p>이미 신청이 완료되었습니다.</p>
+    <p>하루에 한 번만 참여할 수 있습니다.</p>
   </div>
 );

--- a/packages/service/src/common/utils/regex.ts
+++ b/packages/service/src/common/utils/regex.ts
@@ -1,0 +1,4 @@
+export const isValidPhoneNumber = (phone: string) => {
+  const phoneRegex = /^010-(\d{3,4})-(\d{4})$/;
+  return phoneRegex.test(phone);
+};

--- a/packages/service/src/components/nQuizEvent/NQuizReward/NQuizReward.css.ts
+++ b/packages/service/src/components/nQuizEvent/NQuizReward/NQuizReward.css.ts
@@ -54,7 +54,7 @@ export const imgStyle = css`
   object-fit: contain;
 
   ${mobile(css`
-    width: 65%;
+    width: 55%;
   `)}
 `;
 

--- a/packages/service/src/components/nQuizEvent/NQuizReward/NQuizReward.css.ts
+++ b/packages/service/src/components/nQuizEvent/NQuizReward/NQuizReward.css.ts
@@ -49,7 +49,7 @@ export const rewardContainerStyle = (status: EventStatusType) => css`
 `;
 
 export const imgStyle = css`
-  width: 70%;
+  width: 65%;
   aspect-ratio: 1 / 1;
   object-fit: contain;
 
@@ -61,14 +61,14 @@ export const imgStyle = css`
 export const nameStyle = css`
   ${theme.font.preB16}
   text-align: center;
-  font-size: 12px;
+  font-size: calc(10px + 0.4vw);
   color: black;
   padding-top: 7%;
   padding-bottom: 7%;
   word-break: keep-all;
 
   ${mobile(css`
-    font-size: 10px;
+    font-size: calc(10px + 0.6vw);
   `)}
 `;
 

--- a/packages/service/src/pages/NQuizEventWinnerApply/NQuizEventWinnerApply.css.ts
+++ b/packages/service/src/pages/NQuizEventWinnerApply/NQuizEventWinnerApply.css.ts
@@ -91,7 +91,7 @@ export const inputContainerStyle = css`
   justify-content: center;
 `;
 
-export const inputStyle = css`
+export const inputStyle = (isPhoneNumberValid: boolean) => css`
   display: flex;
   width: 566px;
   height: 52px;
@@ -101,6 +101,8 @@ export const inputStyle = css`
   align-self: stretch;
   border-radius: 8px;
   background: var(--Gray-100, #ececec);
+
+  outline: 1px solid ${isPhoneNumberValid ? theme.color.eventBlue : "#FF6B6B"};
 `;
 
 export const listStyle = css`

--- a/packages/service/src/pages/NQuizEventWinnerApply/NQuizEventWinnerApply.css.ts
+++ b/packages/service/src/pages/NQuizEventWinnerApply/NQuizEventWinnerApply.css.ts
@@ -134,3 +134,11 @@ export const centeredContainerStyle = css`
   align-items: center;
   justify-content: center;
 `;
+
+export const submitButtonStyle = css`
+  background-color: ${theme.color.eventBlue};
+
+  :hover {
+    background-color: ${theme.color.eventSkyblue};
+  }
+`;

--- a/packages/service/src/pages/NQuizEventWinnerApply/NQuizEventWinnerApply.css.ts
+++ b/packages/service/src/pages/NQuizEventWinnerApply/NQuizEventWinnerApply.css.ts
@@ -12,13 +12,13 @@ export const backgroundStyle = css`
   ${theme.flex.center}
   ${theme.flex.column}
 
-  padding: 100px 18vw;
+  padding: 100px 20%;
   padding-bottom: 94px;
 
   gap: 20px;
 
   ${mobile(css`
-    min-width: 0px;
+    min-height: calc(100vh - 122px);
     padding: 20vw 6vw;
     padding-bottom: 47px;
   `)};
@@ -56,7 +56,7 @@ export const titleStyle = css`
 
 export const contentContainerStyle = css`
   ${theme.flex.center};
-  ${theme.flex.column};
+  ${theme.flex.column}
   ${theme.gap.gap8};
 
   ${mobile(css`
@@ -70,7 +70,7 @@ export const cheersTextStyle = css`
   text-align: center;
 
   ${mobile(css`
-    font-size: 14px;
+    font-size: 28px;
   `)}
 `;
 
@@ -105,24 +105,38 @@ export const inputStyle = (isPhoneNumberValid: boolean) => css`
   outline: 1px solid ${isPhoneNumberValid ? theme.color.eventBlue : "#FF6B6B"};
 `;
 
+export const termListWrapStyle = css`
+  display: flex;
+  flex-direction: column;
+  width: 96%;
+  max-width: 570px;
+  gap: 10px;
+`;
+
 export const listStyle = css`
-  width: 566px;
   display: flex;
   flex-direction: column;
   color: ${theme.color.gray300};
   align-items: start;
-  gap: 10px;
+  width: 100%;
+  gap: 4px;
 `;
 
 export const listItemStyle = css`
-  ${theme.font.preM18}
+  ${theme.font.preM}
   color: ${theme.color.gray300};
+  font-size: 16px;
   margin-left: 22px;
+
+  ${mobile(css`
+    font-size: 12px;
+    margin-left: 18px;
+  `)}
 `;
 
 export const rewardContainerStyle = css`
   width: 200px;
-  height: 300px;
+  height: fit-content;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/packages/service/src/pages/NQuizEventWinnerApply/NQuizEventWinnerApply.tsx
+++ b/packages/service/src/pages/NQuizEventWinnerApply/NQuizEventWinnerApply.tsx
@@ -30,10 +30,13 @@ import {
   MODAL_CONTENT_ORDER_EVENT_APPLY_SUCCESS,
   MODAL_N_QUIZ_TITLE,
 } from "@service/common/components/ModalContainer/content/modalContent";
+import { isValidPhoneNumber } from "@service/common/utils/regex";
 
 export const NQuizEventWinnerApply = () => {
   const [isChecked, setIsChecked] = useState<boolean>(false);
   const [phoneNumber, setPhoneNumber] = useState<string>("");
+  const [isPhoneNumberValid, setIsPhoneNumberValid] = useState<boolean>(true);
+  const [isSubmitDisabled, setIsSubmitDisabled] = useState<boolean>(true);
   const { openModal } = useModal();
   const navigate = useNavigate();
 
@@ -46,11 +49,6 @@ export const NQuizEventWinnerApply = () => {
   const openedQuiz = quizList.find(
     (quiz) => quiz.status === "OPEN",
   ) as IOrderEvent;
-
-  const handlePhoneNumberChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const targetValue = phoneNumberAutoFormat(e.target.value);
-    setPhoneNumber(targetValue);
-  };
 
   const handleSubmit = () => {
     if (!localStorage.getItem("ApplyTicket") || !openedQuiz) {
@@ -84,12 +82,26 @@ export const NQuizEventWinnerApply = () => {
     });
   };
 
+  const handlePhoneNumberChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const targetValue = phoneNumberAutoFormat(e.target.value);
+    setPhoneNumber(targetValue);
+    setIsPhoneNumberValid(isValidPhoneNumber(targetValue));
+  };
+
   useEffect(() => {
     if (!localStorage.getItem("ApplyTicket")) {
       alert("권한이 없습니다.");
       navigate(MAIN_PAGE_ROUTE);
     }
   }, [navigate]);
+
+  useEffect(() => {
+    if (isValidPhoneNumber(phoneNumber) && isChecked) {
+      setIsSubmitDisabled(false);
+    } else {
+      setIsSubmitDisabled(true);
+    }
+  }, [phoneNumber, isChecked]);
 
   return (
     <div css={backgroundStyle}>
@@ -116,7 +128,8 @@ export const NQuizEventWinnerApply = () => {
 
       <div css={inputContainerStyle}>
         <input
-          css={inputStyle}
+          autoFocus
+          css={inputStyle(isPhoneNumberValid)}
           placeholder="전화번호 입력"
           value={phoneNumber}
           onChange={handlePhoneNumberChange}
@@ -137,7 +150,9 @@ export const NQuizEventWinnerApply = () => {
         </li>
       </ul>
 
-      <Button onClick={handleSubmit}>제출하기</Button>
+      <Button onClick={handleSubmit} disabled={isSubmitDisabled}>
+        제출하기
+      </Button>
     </div>
   );
 };

--- a/packages/service/src/pages/NQuizEventWinnerApply/NQuizEventWinnerApply.tsx
+++ b/packages/service/src/pages/NQuizEventWinnerApply/NQuizEventWinnerApply.tsx
@@ -25,6 +25,7 @@ import {
   rewardContainerStyle,
   centeredContainerStyle,
   submitButtonStyle,
+  termListWrapStyle,
 } from "./NQuizEventWinnerApply.css";
 import { useModal } from "@watermelon-clap/core/src/hooks";
 import {
@@ -148,17 +149,19 @@ export const NQuizEventWinnerApply = () => {
         />
       </div>
 
-      <CheckBox
-        isChecked={isChecked}
-        setIsChecked={setIsChecked}
-        text="개인정보 수집 및 이용 약관에 동의합니다. (이벤트 참가자 식별 및 경품 발송)"
-      />
-      <ul css={listStyle}>
-        <li css={listItemStyle}>경품은 추후 문자를 통해 발송됩니다.</li>
-        <li css={listItemStyle}>
-          번호 제출 전 페이지를 이탈하면 당첨이 취소됩니다.
-        </li>
-      </ul>
+      <div css={termListWrapStyle}>
+        <CheckBox
+          isChecked={isChecked}
+          setIsChecked={setIsChecked}
+          text="개인정보 수집 및 이용 약관에 동의합니다. (이벤트 참가자 식별 및 경품 발송)"
+        />
+        <ul css={listStyle}>
+          <li css={listItemStyle}>경품은 추후 문자를 통해 발송됩니다.</li>
+          <li css={listItemStyle}>
+            번호 제출 전 페이지를 이탈하면 당첨이 취소됩니다.
+          </li>
+        </ul>
+      </div>
 
       <Button
         css={submitButtonStyle}

--- a/packages/service/src/pages/NQuizEventWinnerApply/NQuizEventWinnerApply.tsx
+++ b/packages/service/src/pages/NQuizEventWinnerApply/NQuizEventWinnerApply.tsx
@@ -24,9 +24,11 @@ import {
   listItemStyle,
   rewardContainerStyle,
   centeredContainerStyle,
+  submitButtonStyle,
 } from "./NQuizEventWinnerApply.css";
 import { useModal } from "@watermelon-clap/core/src/hooks";
 import {
+  MODAL_CONTENT_ORDER_EVENT_APPLY_DUPPLICATION,
   MODAL_CONTENT_ORDER_EVENT_APPLY_SUCCESS,
   MODAL_N_QUIZ_TITLE,
 } from "@service/common/components/ModalContainer/content/modalContent";
@@ -76,6 +78,14 @@ export const NQuizEventWinnerApply = () => {
           props: {
             title: MODAL_N_QUIZ_TITLE,
             content: MODAL_CONTENT_ORDER_EVENT_APPLY_SUCCESS,
+          },
+        });
+      } else {
+        openModal({
+          type: "alert",
+          props: {
+            title: MODAL_N_QUIZ_TITLE,
+            content: MODAL_CONTENT_ORDER_EVENT_APPLY_DUPPLICATION,
           },
         });
       }
@@ -150,7 +160,11 @@ export const NQuizEventWinnerApply = () => {
         </li>
       </ul>
 
-      <Button onClick={handleSubmit} disabled={isSubmitDisabled}>
+      <Button
+        css={submitButtonStyle}
+        onClick={handleSubmit}
+        disabled={isSubmitDisabled}
+      >
         제출하기
       </Button>
     </div>


### PR DESCRIPTION
# 🔗 연관된 이슈

- [연관된 이슈 링크](https://watermelon-clap.atlassian.net/browse/CLAP-158?atlOrigin=eyJpIjoiYjRhYTRlYWI3NjFjNDFlZWI3ZGUxYzBkOGYzMzgxMWMiLCJwIjoiaiJ9)
  
<br/>

# 📗 작업 내용
선착순 퀴즈 당첨자 입력 폼 수정

### 이슈 내용
- 전화번호 입력이 올바르게 되었는지 사용자가 인지하기 힘든 이슈
- 올바른 번호가 입력되고, 체크박스가 체크되지 않아도 버튼이 눌리는 이슈
- 중복 제출의 경우 아무런 안내가 나오지 않던 이슈


### 변경 사항
- 전화번호 정규식을 추가하여, 입력폼의 보더의 색상에 따라 올바르게 입력되었는지 사용자가 알기 쉽게 조정함
- 올바른 번호 입력 및 체크박스 체크 전까지는 버튼을 disable상태로 변경
- 중복 제출의 경우 알림 모달을 통해 유저에게 알려주는 기능 추가

https://github.com/user-attachments/assets/7cbff242-ae94-4a59-b688-0471398ac283


<br/>


# ✏️ 리뷰어 멘션
@thgee 
