### PR TITLE
feat(CLAP-140): 파츠 컬렉션 페이지 파츠 상세설명, 장착버튼

### DIFF
--- a/packages/service/src/common/components/ModalContainer/ModalContainer.tsx
+++ b/packages/service/src/common/components/ModalContainer/ModalContainer.tsx
@@ -11,9 +11,17 @@ import {
   NavigateModalProps,
   ConfirmModal,
   ConfirmModalProps,
+  DescriptionModal,
+  DescriptionModalProps,
 } from "./modal";
 
-export type ModalType = "login" | "alert" | "pending" | "navigate" | "confirm";
+export type ModalType =
+  | "login"
+  | "alert"
+  | "pending"
+  | "navigate"
+  | "confirm"
+  | "description";
 
 export interface DefaultModalProps {
   isOpen: boolean;
@@ -26,6 +34,7 @@ interface ModalComponentMap {
   pending: React.FC<DefaultModalProps>;
   navigate: React.FC<NavigateModalProps>;
   confirm: React.FC<ConfirmModalProps>;
+  description: React.FC<DescriptionModalProps>;
 }
 
 const MODAL_COMPONENT_MAP: ModalComponentMap = {
@@ -34,6 +43,7 @@ const MODAL_COMPONENT_MAP: ModalComponentMap = {
   pending: PendingModal,
   navigate: NavigateModal,
   confirm: ConfirmModal,
+  description: DescriptionModal,
 };
 
 export const ModalContainer = () => {

--- a/packages/service/src/common/components/ModalContainer/modal/DescriptionModal/DescriptionModal.css.ts
+++ b/packages/service/src/common/components/ModalContainer/modal/DescriptionModal/DescriptionModal.css.ts
@@ -1,0 +1,50 @@
+import { css } from "@emotion/react";
+import { mobile } from "@service/common/responsive/responsive";
+import { theme } from "@watermelon-clap/core/src/theme";
+
+export const descriptionModalStyles = {
+  content: {
+    top: "50%",
+    left: "50%",
+    right: "auto",
+    bottom: "auto",
+    marginRight: "-50%",
+    transform: "translate(-50%, -50%)",
+    borderRadius: "10px",
+    border: "none",
+    boxShadow: "0 2px 10px rgba(0, 0, 0, 0.2)",
+  },
+  overlay: {
+    backgroundColor: "rgba(0, 0, 0, 0.5)",
+    zIndex: 1000,
+  },
+};
+
+export const descriptionModalBodyStyles = css`
+  ${theme.flex.center}
+  ${theme.flex.column}
+  gap: 30px;
+  padding: 23px 10px;
+  width: 350px;
+  text-align: center;
+
+  ${mobile(css`
+    width: 70vw;
+    padding: 20px 10px;
+  `)}
+`;
+
+export const imageStyle = css`
+  width: 300px;
+  border-radius: 20px;
+
+  ${mobile(css`
+    border-radius: 10px;
+    width: 60vw;
+  `)}
+`;
+
+export const descriptionStyle = css`
+  word-break: keep-all;
+  white-space: pre-wrap;
+`;

--- a/packages/service/src/common/components/ModalContainer/modal/DescriptionModal/DescriptionModal.tsx
+++ b/packages/service/src/common/components/ModalContainer/modal/DescriptionModal/DescriptionModal.tsx
@@ -1,0 +1,43 @@
+import Modal from "react-modal";
+import { Button } from "../../../Button";
+import { useScrollStop } from "@watermelon-clap/core/src/hooks";
+import {
+  descriptionModalStyles,
+  descriptionModalBodyStyles,
+  imageStyle,
+  descriptionStyle,
+} from "./DescriptionModal.css";
+import { DefaultModalProps } from "../../ModalContainer";
+
+export interface DescriptionModalProps extends DefaultModalProps {
+  src: string;
+  name: string;
+  description: string;
+}
+
+export const DescriptionModal = ({
+  isOpen,
+  onRequestClose,
+  src,
+  name,
+  description,
+}: DescriptionModalProps) => {
+  useScrollStop(isOpen);
+
+  return (
+    <Modal
+      shouldCloseOnEsc
+      isOpen={isOpen}
+      onRequestClose={onRequestClose}
+      style={descriptionModalStyles}
+      ariaHideApp={false}
+    >
+      <div css={descriptionModalBodyStyles}>
+        <img css={imageStyle} src={src} alt={name}></img>
+        <h2>{name}</h2>
+        <p css={descriptionStyle}>{description}</p>
+        <Button onClick={onRequestClose}>확인</Button>
+      </div>
+    </Modal>
+  );
+};

--- a/packages/service/src/common/components/ModalContainer/modal/DescriptionModal/index.ts
+++ b/packages/service/src/common/components/ModalContainer/modal/DescriptionModal/index.ts
@@ -1,0 +1,1 @@
+export * from "./DescriptionModal";

--- a/packages/service/src/common/components/ModalContainer/modal/index.ts
+++ b/packages/service/src/common/components/ModalContainer/modal/index.ts
@@ -3,3 +3,4 @@ export * from "./AlertModal";
 export * from "./PendingModal";
 export * from "./NavigateModal";
 export * from "./ConfirmModal";
+export * from "./DescriptionModal";

--- a/packages/service/src/components/partsCollection/PartsTab/PartsCard/PartsCard.css.ts
+++ b/packages/service/src/components/partsCollection/PartsTab/PartsCard/PartsCard.css.ts
@@ -6,10 +6,11 @@ export const container = css`
   ${theme.flex.column}
   width : 31.2%;
   cursor: pointer;
+  gap: 6px;
 
   ${mobile(css`
     width: 46%;
-  `)}
+  `)};
 `;
 
 export const card = (equipped: boolean) => css`
@@ -43,11 +44,11 @@ export const card = (equipped: boolean) => css`
     color: ${theme.color.white};
     ${theme.font.preB24}
     font-size: 16px;
-    background-color: ${theme.color.eventBlue};
+    background-color: ${theme.color.gray400};
     padding: 10px 20px;
     animation: fadeInOut 1s infinite alternate;
 
-    width: 80%;
+    width: 100%;
     height: 5%;
     bottom: 0;
 
@@ -75,10 +76,51 @@ export const img = (cate: string) => css`
 export const name = css`
   ${theme.font.preB16};
   color: ${theme.color.white};
-  margin-top: 20px;
+  margin-top: 6px;
 
   ${mobile(css`
     font-size: 14px;
-    margin-top: 10px;
   `)}
+`;
+
+export const buttonWrap = css`
+  width: 100%;
+  ${theme.flex.center}
+  gap: 4px;
+`;
+
+export const partsDescriptionButton = css`
+  width: 48%;
+  font-size: 14px;
+  height: fit-content;
+  padding: 4px 10px;
+  background-color: ${theme.color.white};
+  color: ${theme.color.black};
+
+  :active {
+    background-color: ${theme.color.gray200};
+    color: ${theme.color.black};
+  }
+
+  ${mobile(css`
+    font-size: 14px;
+    margin-top: 2px;
+    padding: 2px 4px;
+    width: 50%;
+  `)}
+`;
+
+export const partsEquipButton = css`
+  width: 48%;
+  font-size: 14px;
+  height: fit-content;
+  padding: 4px 10px;
+
+  background-color: ${theme.color.eventBlue};
+  color: ${theme.color.white};
+
+  :active {
+    background-color: ${theme.color.eventSkyblue};
+    color: ${theme.color.white};
+  }
 `;

--- a/packages/service/src/components/partsCollection/PartsTab/PartsCard/PartsCard.css.ts
+++ b/packages/service/src/components/partsCollection/PartsTab/PartsCard/PartsCard.css.ts
@@ -103,10 +103,9 @@ export const partsDescriptionButton = css`
   }
 
   ${mobile(css`
-    font-size: 14px;
     margin-top: 2px;
     padding: 2px 4px;
-    width: 50%;
+    width: 48%;
   `)}
 `;
 
@@ -123,4 +122,10 @@ export const partsEquipButton = css`
     background-color: ${theme.color.eventSkyblue};
     color: ${theme.color.white};
   }
+
+  ${mobile(css`
+    margin-top: 2px;
+    padding: 2px 4px;
+    width: 48%;
+  `)}
 `;

--- a/packages/service/src/components/partsCollection/PartsTab/PartsCard/PartsCard.tsx
+++ b/packages/service/src/components/partsCollection/PartsTab/PartsCard/PartsCard.tsx
@@ -1,8 +1,12 @@
+import { Button } from "@service/common/components/Button";
 import * as style from "./PartsCard.css";
 import { apiPatchMyParts } from "@service/apis/partsEvent/apiPatchMyParts";
 import { RefetchOptions, QueryObserverResult } from "@tanstack/react-query";
 import { IParts, IMyParts } from "@watermelon-clap/core/src/types";
 import { getAccessToken } from "@watermelon-clap/core/src/utils";
+import { useState } from "react";
+import { useMobile } from "@service/common/hooks/useMobile";
+import { useModal } from "@watermelon-clap/core/src/hooks";
 
 interface IPartsCardProps {
   partsData: IParts;
@@ -15,6 +19,21 @@ export const PartsCard = ({
   partsData,
   refetchGetMyParts,
 }: IPartsCardProps) => {
+  const [isHovered, setIsHovered] = useState(false);
+  const isMobile = useMobile();
+  const { openModal } = useModal();
+
+  const handleDescriptionButtonClick = () => {
+    openModal({
+      type: "description",
+      props: {
+        src: partsData.thumbnailImgSrc,
+        name: partsData.name,
+        description: partsData.description,
+      },
+    });
+  };
+
   const handleClickCard = () => {
     apiPatchMyParts(getAccessToken() as string, partsData.partsId).then(() =>
       refetchGetMyParts(),
@@ -22,14 +41,34 @@ export const PartsCard = ({
   };
 
   return (
-    <div css={style.container} onClick={handleClickCard}>
-      <div css={style.card(partsData.equipped)}>
+    <div
+      css={style.container}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      <div css={style.card(partsData.equipped)} onClick={handleClickCard}>
         <img
           src={partsData.thumbnailImgSrc}
           css={style.img(partsData.category)}
         />
       </div>
-      <span css={style.name}>{partsData.name}</span>
+      {isHovered ? (
+        <div css={style.buttonWrap}>
+          <Button
+            css={style.partsDescriptionButton}
+            onClick={handleDescriptionButtonClick}
+          >
+            상세설명
+          </Button>
+          {!isMobile && (
+            <Button css={style.partsEquipButton} onClick={handleClickCard}>
+              {partsData.equipped ? "장착해제" : "장착하기"}
+            </Button>
+          )}
+        </div>
+      ) : (
+        <span css={style.name}>{partsData.name}</span>
+      )}
     </div>
   );
 };

--- a/packages/service/src/components/partsCollection/PartsTab/PartsCard/PartsCard.tsx
+++ b/packages/service/src/components/partsCollection/PartsTab/PartsCard/PartsCard.tsx
@@ -5,8 +5,8 @@ import { RefetchOptions, QueryObserverResult } from "@tanstack/react-query";
 import { IParts, IMyParts } from "@watermelon-clap/core/src/types";
 import { getAccessToken } from "@watermelon-clap/core/src/utils";
 import { useState } from "react";
-import { useMobile } from "@service/common/hooks/useMobile";
 import { useModal } from "@watermelon-clap/core/src/hooks";
+import { useMobile } from "@service/common/hooks/useMobile";
 
 interface IPartsCardProps {
   partsData: IParts;
@@ -20,8 +20,8 @@ export const PartsCard = ({
   refetchGetMyParts,
 }: IPartsCardProps) => {
   const [isHovered, setIsHovered] = useState(false);
-  const isMobile = useMobile();
   const { openModal } = useModal();
+  const isMobile = useMobile();
 
   const handleDescriptionButtonClick = () => {
     openModal({
@@ -46,7 +46,10 @@ export const PartsCard = ({
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >
-      <div css={style.card(partsData.equipped)} onClick={handleClickCard}>
+      <div
+        css={style.card(partsData.equipped)}
+        onClick={isMobile ? () => {} : handleClickCard}
+      >
         <img
           src={partsData.thumbnailImgSrc}
           css={style.img(partsData.category)}
@@ -60,11 +63,9 @@ export const PartsCard = ({
           >
             상세설명
           </Button>
-          {!isMobile && (
-            <Button css={style.partsEquipButton} onClick={handleClickCard}>
-              {partsData.equipped ? "장착해제" : "장착하기"}
-            </Button>
-          )}
+          <Button css={style.partsEquipButton} onClick={handleClickCard}>
+            {partsData.equipped ? "장착해제" : "장착하기"}
+          </Button>
         </div>
       ) : (
         <span css={style.name}>{partsData.name}</span>

--- a/packages/service/src/components/partsCollection/PartsTab/PartsTab.css.ts
+++ b/packages/service/src/components/partsCollection/PartsTab/PartsTab.css.ts
@@ -49,6 +49,7 @@ export const partsCardWrap = css`
   display: flex;
   align-items: baseline;
   justify-content: flex-start;
+  align-content: start;
 
   gap: 20px 20px;
   flex-wrap: wrap;


### PR DESCRIPTION
# 🔗 연관된 이슈

- [연관된 이슈 링크](https://watermelon-clap.atlassian.net/browse/CLAP-140?atlOrigin=eyJpIjoiZmJjNTM5ZGQzNGJmNGViN2E5ZjA4MzUyMzI1ZjZmZjciLCJwIjoiaiJ9)
  
<br/>

# 📗 작업 내용
파츠 컬렉션 페이지에서 
각 파츠 별 상세설명, 장착버튼 구현


### 변경 사항
- 파츠 호버 시 상세설명, 장착버튼 노출 (모바일에서는 클릭 시)
- 상세설명을 위해 상세설명 모달 구현
- 장착버튼 또는 파츠 클릭을 통해 파츠 장착 및 해제 가능 ( 모바일에서는 장착버튼으로만 가능 )

https://github.com/user-attachments/assets/e5cceac8-36c9-4788-acec-f041938b4a4a


<br/>


# ✏️ 리뷰어 멘션
@thgee 