### PR TITLE
feat(CLAP-160): 파츠뽑기 카드 하단에 이름 노출

### DIFF
--- a/packages/service/src/components/partsPick/PartsCard/PartsCard.tsx
+++ b/packages/service/src/components/partsPick/PartsCard/PartsCard.tsx
@@ -18,6 +18,8 @@ interface CardProps {
   isMouseOutAnimationEnabled: boolean;
   remainChance: number;
   setIsPickComplete: React.Dispatch<React.SetStateAction<boolean>>;
+  partsInfo: IParts | undefined;
+  setPartsInfo: React.Dispatch<React.SetStateAction<IParts | undefined>>;
 }
 
 const CardWrapper = styled.div<{ color1: string; color2: string }>`
@@ -53,12 +55,13 @@ export const PartsCard = ({
   isMouseOutAnimationEnabled,
   remainChance,
   setIsPickComplete,
+  partsInfo,
+  setPartsInfo,
 }: CardProps) => {
   const cardRef = useRef<HTMLDivElement>(null);
   const styleRef = useRef<HTMLStyleElement>(document.createElement("style"));
   const [isFlipped, setIsFlipped] = useState(false);
   const [isFrontShow, setIsFrontShow] = useState(false);
-  const [partsInfo, setPartsInfo] = useState<IParts>();
   const { getIsLogin } = useAuth();
 
   const handleMouseMove = (e: React.MouseEvent | React.TouchEvent) => {

--- a/packages/service/src/pages/PartsPick/PartsPick.css.ts
+++ b/packages/service/src/pages/PartsPick/PartsPick.css.ts
@@ -36,3 +36,17 @@ export const partsPickModalContentStyle = css`
     margin: 0;
   }
 `;
+
+export const partsNameStyle = css`
+  color: var(--White, #fff);
+  text-align: center;
+  text-shadow: 0px 0px 40px #ffb7ff;
+  -webkit-text-stroke-width: 1;
+  -webkit-text-stroke-color: #fed2ff;
+  ${theme.font.pcpB}
+  font-size: 40px;
+
+  ${mobile(css`
+    font-size: 24px;
+  `)}
+`;

--- a/packages/service/src/pages/PartsPick/PartsPick.tsx
+++ b/packages/service/src/pages/PartsPick/PartsPick.tsx
@@ -3,6 +3,7 @@ import {
   partsPickBackgroundStyle,
   partsPickButtonStyle,
   partsPickModalContentStyle,
+  partsNameStyle,
 } from "./PartsPick.css";
 import { PartsCard, PickTitle } from "@service/components/partsPick";
 import { Space } from "@service/common/styles/Space";
@@ -14,6 +15,14 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { apiGetPartsRemain } from "@service/apis/partsEvent";
 import { LOTTER_APPLY_FINISH_PAGE_ROUTE } from "@service/constants/routes";
 import { apiGetLotteryStatus } from "@service/apis/lottery/apiGetLotteryStatus";
+import { IParts } from "@watermelon-clap/core/src/types";
+
+enum Category {
+  REAR = "스포일러",
+  COLOR = "색상",
+  DRIVE_MODE = "배경",
+  WHEEL = "휠",
+}
 
 export const PartsPick = () => {
   const { openModal } = useModal();
@@ -23,6 +32,7 @@ export const PartsPick = () => {
   const [remainChance, setRemainChance] = useState(
     useLocation()?.state?.remainChance,
   );
+  const [partsInfo, setPartsInfo] = useState<IParts>();
   const { getIsLogin, login } = useAuth();
   const navigate = useNavigate();
   const isApplied = useRef(false);
@@ -81,7 +91,16 @@ export const PartsPick = () => {
           isMouseOutAnimationEnabled={false}
           remainChance={remainChance}
           setIsPickComplete={setIsPickComplete}
+          partsInfo={partsInfo}
+          setPartsInfo={setPartsInfo}
         />
+        <Space size={isMobile ? 4 : 6} />
+        {isPickComplete && (
+          <p css={partsNameStyle}>
+            "{partsInfo?.name}" &nbsp;
+            {Category[partsInfo?.category as keyof typeof Category]} 당첨!
+          </p>
+        )}
         <Space size={isMobile ? 16 : 32} />
         {(isPickComplete || remainChance < 0) && (
           <>


### PR DESCRIPTION
# 🔗 연관된 이슈

- [연관된 이슈 링크](https://watermelon-clap.atlassian.net/browse/CLAP-160?atlOrigin=eyJpIjoiNzQyOTYxMjllNjBhNDA0YWI2NjdkOWM2ZDY1ZjM0NzMiLCJwIjoiaiJ9)
  
<br/>

# 📗 작업 내용
파츠카드를 뽑을 시 하단부에 이름이 노출되도록 함

### 이슈 내용
- 파츠카드 하단부에 이름이 노출되지 않았던 이슈


### 변경 사항
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/f2f49b48-ecff-4aee-93c2-5c358cbd0c33">

<img width="389" alt="image" src="https://github.com/user-attachments/assets/f6bcf98d-175f-46e1-becd-189e6bb4239d">


<br/>


# ✏️ 리뷰어 멘션
@thgee 
