### PR TITLE
chore(CLAP-159): 컴포넌트 크기 축소

### DIFF
--- a/packages/service/src/components/main/Banner/Banner.tsx
+++ b/packages/service/src/components/main/Banner/Banner.tsx
@@ -63,7 +63,7 @@ export const Banner = () => {
     scroller.scrollTo("scrollMove", {
       duration: 700,
       smooth: true,
-      offset: -50,
+      offset: -60,
     });
   };
 

--- a/packages/service/src/components/main/EventCard/EventCard.css.ts
+++ b/packages/service/src/components/main/EventCard/EventCard.css.ts
@@ -5,31 +5,30 @@ import { theme } from "@watermelon-clap/core/src/theme";
 export const eventCard = (isMainEvent: boolean) => css`
   padding: 72px;
   background: ${isMainEvent ? theme.color.mainEventCardBg : theme.color.white};
-  width: 552px;
+  width: 452px;
   border-radius: 20px;
   text-align: center;
   white-space: pre-wrap;
-  gap: 38px;
   box-shadow: 0px 0px 100px 0px rgba(255, 255, 255, 0.5);
 
   ${mobile(css`
-    padding: 24px 18px;
+    padding: 24px;
     width: fit-content;
   `)}
 `;
 export const eventNumber = css`
   border-radius: 50%;
   background-color: ${theme.color.black};
-  width: 44px;
-  height: 44px;
+  width: 34px;
+  height: 34px;
   color: ${theme.color.white};
   margin: 0 auto;
   ${theme.flex.center}
   ${theme.font.preB24}
 
   ${mobile(css`
-    width: 34px;
-    height: 34px;
+    width: 28px;
+    height: 28px;
     font-size: 18px;
   `)}
 `;
@@ -37,42 +36,45 @@ export const eventNumber = css`
 export const eventTitle = css`
   ${theme.font.pcpB};
   ${theme.margin.mg12}
-  font-size: 40px;
+  font-size: 30px;
+
+  ${mobile(css`
+    font-size: 16px;
+  `)}
+`;
+
+export const joinButton = css`
+  ${theme.font.preB};
+  font-size: 24px;
+  width: 80%;
+  height: 70px;
+  border-radius: 18px;
+`;
+
+export const eventType = css`
+  ${theme.font.preB};
+  font-size: 26px;
+  margin-top: 28px;
+  margin-bottom: 12px;
 
   ${mobile(css`
     font-size: 24px;
   `)}
 `;
-
-export const joinButton = css`
-  ${theme.font.preB38};
-  width: 100%;
-  height: 120px;
-  border-radius: 18px;
-`;
-
-export const eventType = css`
-  ${theme.font.preB28};
-  margin-top: 28px;
-  margin-bottom: 12px;
-
-  ${mobile(css`
-    font-size: 28px;
-  `)}
-`;
 export const subTitle = css`
-  ${theme.font.preB24};
-
+  ${theme.font.preB};
+  font-size: 20px;
   ${mobile(css`
-    font-size: 18px;
+    font-size: 14px;
   `)}
 `;
 
 export const desc = css`
-  ${theme.font.preM20}
+  ${theme.font.preM}
+  font-size : 18px;
   margin: 20px 0;
 
   ${mobile(css`
-    font-size: 1.1rem;
+    font-size: 0.9rem;
   `)}
 `;

--- a/packages/service/src/components/main/EventCard/EventCard.tsx
+++ b/packages/service/src/components/main/EventCard/EventCard.tsx
@@ -25,13 +25,13 @@ export const EventCard = ({ eventData }: IEventDataProps) => {
   return (
     <div css={style.eventCard(eventData.id === 1)}>
       <div css={style.eventNumber}>{eventData.id}</div>
-      <div css={[theme.flex.column, theme.gap.gap32]}>
+      <div css={[theme.flex.column, theme.gap.gap24]}>
         <div>
           <h2 css={style.eventType}>{eventData.eventType}</h2>
           <h1 css={style.eventTitle}>{eventData.title}</h1>
           <h3 css={style.subTitle}> {eventData.subTitle}</h3>
         </div>
-        <img src={eventData.img} width={isMobile ? 200 : 300} />
+        <img src={eventData.img} width={isMobile ? 140 : 240} />
 
         <p css={style.desc}>{eventData.desc}</p>
 

--- a/packages/service/src/components/main/EventPeriod/EventPeriod.css.ts
+++ b/packages/service/src/components/main/EventPeriod/EventPeriod.css.ts
@@ -12,9 +12,9 @@ export const container = css`
 `;
 
 export const period = css`
-  ${theme.font.pcpL32};
+  ${theme.font.pcpL};
   -webkit-text-stroke-width: 1px;
-  font-size: calc(20px + 2vw);
+  font-size: calc(10px + 2vw);
   color: ${theme.color.eventSkyblue};
   margin-top: 10px;
 
@@ -25,7 +25,7 @@ export const period = css`
 
 export const title = css`
   ${theme.font.pcpB};
-  font-size: calc(40px + 3vw);
+  font-size: calc(20px + 3vw);
 
   ${mobile(css`
     font-size: 26px;

--- a/packages/service/src/components/main/EventPeriod/Timer/Timer.css.ts
+++ b/packages/service/src/components/main/EventPeriod/Timer/Timer.css.ts
@@ -16,14 +16,14 @@ export const staticCardStyles = (position: "upper" | "lower") => css`
 
 export const textStyles = (translateY?: string, title?: string) => css`
   ${theme.font.pcpL}
-  font-size: calc(10px + 3vw);
+  font-size: calc(10px + 2vw);
   -webkit-text-stroke-width: 2px;
-  font-weight: normal;
   transform: translateY(${translateY});
   color: ${title === "days" ? theme.color.eventBlue : theme.color.white};
 
   ${mobile(css`
-    font-size: 30px;
+    font-size: 20px;
+    -webkit-text-stroke-width: 2px;
   `)}
 `;
 
@@ -41,8 +41,6 @@ export const animatedCardStyles = css`
   transform-origin: 50% 100%;
   background-color: #000000;
   border-radius: 6px 6px 0 0;
-
-  ${mobile(css``)}
 `;
 
 export const animatedCardBottomStyles = css`
@@ -104,10 +102,10 @@ export const rendererWrap1 = css`
 export const rendererWrap2 = css`
   display: flex;
   align-items: center;
-  gap: calc(10px + 2vw);
+  gap: calc(10px + 1.3vw);
   justify-content: center;
 
   ${mobile(css`
-    gap: 0.3rem;
+    gap: 0.2rem;
   `)};
 `;

--- a/packages/service/src/components/main/EventPeriod/Timer/Timer.css.ts
+++ b/packages/service/src/components/main/EventPeriod/Timer/Timer.css.ts
@@ -16,7 +16,7 @@ export const staticCardStyles = (position: "upper" | "lower") => css`
 
 export const textStyles = (translateY?: string, title?: string) => css`
   ${theme.font.pcpL}
-  font-size: calc(20px + 3vw);
+  font-size: calc(10px + 3vw);
   -webkit-text-stroke-width: 2px;
   font-weight: normal;
   transform: translateY(${translateY});
@@ -89,6 +89,16 @@ export const rendererWrap1 = css`
   margin: 0 auto;
   box-shadow: 0 0 220px 10px ${theme.color.black};
   width: 70%;
+  padding: 8px 50px;
+  width: fit-content;
+  margin-top: 90px;
+  border: 1px solid ${theme.color.gray400};
+
+  ${mobile(css`
+    border-radius: 30px;
+    padding: 8px 20px;
+    margin-top: 0px;
+  `)}
 `;
 
 export const rendererWrap2 = css`

--- a/packages/service/src/components/newCar/NewCarInfo/NewCarInfo.css.ts
+++ b/packages/service/src/components/newCar/NewCarInfo/NewCarInfo.css.ts
@@ -1,7 +1,7 @@
 import { css } from "@emotion/react";
 import { theme } from "@watermelon-clap/core/src/theme";
 
-const SCROLL_SPEED = "3000vh";
+const SCROLL_SPEED = "2000vh";
 
 export const scrollContainer = css`
   height: ${SCROLL_SPEED};

--- a/packages/service/src/components/newCar/TracingCar/TracingCar.css.ts
+++ b/packages/service/src/components/newCar/TracingCar/TracingCar.css.ts
@@ -2,7 +2,7 @@ import { css } from "@emotion/react";
 import { mobile } from "@service/common/responsive/responsive";
 
 export const bodyStyles = css`
-  height: 3000vh;
+  height: 2000vh;
   width: 100%;
   position: absolute;
   opacity: 0.6;

--- a/packages/service/src/components/pickEvent/CardCarousel/CardCarousel.tsx
+++ b/packages/service/src/components/pickEvent/CardCarousel/CardCarousel.tsx
@@ -7,18 +7,19 @@ export const CardCarousel = () => {
   const settings = {
     infinite: true,
     speed: 800,
-    slidesToShow: 3,
+    slidesToShow: 4,
     slidesToScroll: 1,
     initialSlide: 0,
     autoplay: true,
     autoplaySpeed: 1500,
     arrows: false,
+    draggable: false,
 
     responsive: [
       {
         breakpoint: 1000,
         settings: {
-          slidesToShow: 2,
+          slidesToShow: 3,
           slidesToScroll: 1,
         },
       },

--- a/packages/service/src/components/pickEvent/CardCarousel/CardCarousel.tsx
+++ b/packages/service/src/components/pickEvent/CardCarousel/CardCarousel.tsx
@@ -7,19 +7,18 @@ export const CardCarousel = () => {
   const settings = {
     infinite: true,
     speed: 800,
-    slidesToShow: 4,
+    slidesToShow: 3,
     slidesToScroll: 1,
     initialSlide: 0,
     autoplay: true,
     autoplaySpeed: 1500,
     arrows: false,
-    draggable: false,
 
     responsive: [
       {
         breakpoint: 1000,
         settings: {
-          slidesToShow: 3,
+          slidesToShow: 2,
           slidesToScroll: 1,
         },
       },

--- a/packages/service/src/components/pickEvent/JoinInfo/JoinInfo.css.ts
+++ b/packages/service/src/components/pickEvent/JoinInfo/JoinInfo.css.ts
@@ -14,6 +14,7 @@ export const iconWrap = css`
 
   ${mobile(css`
     gap: 28px;
+    margin: 0 80px;
   `)}
 `;
 

--- a/packages/service/src/components/pickEvent/PrizeContainer/PrizeContainer.css.ts
+++ b/packages/service/src/components/pickEvent/PrizeContainer/PrizeContainer.css.ts
@@ -1,22 +1,21 @@
 import { css } from "@emotion/react";
 import { mobile } from "@service/common/responsive/responsive";
-import { PICK_EVENT_PRIZE_CONTAINER_BREAKPOINT } from "@service/constants/breakpoints";
 import { theme } from "@watermelon-clap/core/src/theme";
 
 export const prizeContainer = css`
   display: flex;
-  flex-direction: column;
-  gap: 160px;
-  width: 1000px;
+  gap: 40px;
+  justify-content: center;
+  align-items: start;
+  width: fit-content;
   margin: 0 auto;
+  flex-wrap: wrap;
 
-  ${mobile(
-    css`
-      align-items: center;
-      width: fit-content;
-    `,
-    PICK_EVENT_PRIZE_CONTAINER_BREAKPOINT,
-  )}
+  ${mobile(css`
+    align-items: center;
+    width: fit-content;
+    gap: 120px;
+  `)}
 `;
 
 export const container = css`
@@ -25,47 +24,39 @@ export const container = css`
   box-shadow: 0px 0px 10px 0px #fff;
   color: ${theme.color.white};
   ${theme.flex.column}
-  padding: 120px 80px;
+  width : 550px;
+  padding: 80px;
 
-  ${mobile(
-    css`
-      width: fit-content;
-      padding: 10px;
-      border: none;
-      box-shadow: none;
-    `,
-    PICK_EVENT_PRIZE_CONTAINER_BREAKPOINT,
-  )}
+  ${mobile(css`
+    width: fit-content;
+    padding: 10px;
+    border: none;
+    box-shadow: none;
+  `)}
 `;
 
 export const title = css`
   ${theme.font.pcpB}
   text-align : center;
-  font-size: clamp(0px, calc(4vw + 10px), 64px);
-  margin-bottom: 80px;
+  font-size: clamp(0px, calc(3vw + 10px), 44px);
+  margin-bottom: 40px;
 
-  ${mobile(
-    css`
-      width: 320px;
-      font-size: 40px;
-      border-left: 3px solid white;
-      border-right: 3px solid white;
-      padding: 0 10px;
-    `,
-    PICK_EVENT_PRIZE_CONTAINER_BREAKPOINT,
-  )}
+  ${mobile(css`
+    width: 260px;
+    font-size: 28px;
+    border-left: 3px solid white;
+    border-right: 3px solid white;
+    padding: 0 10px;
+  `)}
 `;
 
 export const prizeWrap = css`
   display: grid;
-  gap: 120px;
+  gap: 70px;
   margin-top: 100px;
   grid-template-columns: repeat(2, 1fr);
 
-  ${mobile(
-    css`
-      grid-template-columns: 1fr;
-    `,
-    PICK_EVENT_PRIZE_CONTAINER_BREAKPOINT,
-  )}
+  ${mobile(css`
+    grid-template-columns: 1fr;
+  `)}
 `;

--- a/packages/service/src/components/pickEvent/PrizeContainer/PrizeContainer.css.ts
+++ b/packages/service/src/components/pickEvent/PrizeContainer/PrizeContainer.css.ts
@@ -57,6 +57,6 @@ export const prizeWrap = css`
   grid-template-columns: repeat(2, 1fr);
 
   ${mobile(css`
-    grid-template-columns: 1fr;
+    gap: 50px 30px;
   `)}
 `;

--- a/packages/service/src/components/pickEvent/PrizeContainer/PrizeContainer.tsx
+++ b/packages/service/src/components/pickEvent/PrizeContainer/PrizeContainer.tsx
@@ -6,8 +6,8 @@ export const PrizeContainer = () => {
   return (
     <div css={style.prizeContainer}>
       <div css={style.container}>
-        <h1 css={style.title}>경품 안내</h1>
-        <PrizeItem {...winnerPrizeData} imgSize="500px" />
+        <h1 css={style.title}>추첨 경품</h1>
+        <PrizeItem {...winnerPrizeData} winner />
         <div css={style.prizeWrap}>
           {prizeData.map((info, idx) => (
             <PrizeItem {...info} key={idx} />
@@ -15,8 +15,8 @@ export const PrizeContainer = () => {
         </div>
       </div>
       <div css={style.container}>
-        <h1 css={style.title}>미니어처 이벤트 경품 안내</h1>
-        <PrizeItem {...miniatureData} />
+        <h1 css={style.title}>미니어처 경품</h1>
+        <PrizeItem winner {...miniatureData} />
       </div>
     </div>
   );

--- a/packages/service/src/components/pickEvent/PrizeContainer/PrizeItem/PrizeItem.css.ts
+++ b/packages/service/src/components/pickEvent/PrizeContainer/PrizeItem/PrizeItem.css.ts
@@ -15,7 +15,7 @@ export const img = (winner?: boolean) => css`
   width: ${winner ? "300px" : "180px"};
 
   ${mobile(css`
-    width: ${winner ? "200px" : "140px"};
+    width: ${winner ? "200px" : "90px"};
     margin-bottom: 20px;
   `)}
 `;
@@ -23,9 +23,16 @@ export const img = (winner?: boolean) => css`
 export const rank = css`
   font-size: 16px;
   margin-bottom: 14px;
+  ${mobile(css`
+    font-size: 12px;
+  `)}
 `;
 
 export const name = css`
   font-size: 22px;
   width: 180px;
+  ${mobile(css`
+    font-size: 16px;
+    width: 140px;
+  `)}
 `;

--- a/packages/service/src/components/pickEvent/PrizeContainer/PrizeItem/PrizeItem.css.ts
+++ b/packages/service/src/components/pickEvent/PrizeContainer/PrizeItem/PrizeItem.css.ts
@@ -1,6 +1,5 @@
 import { css } from "@emotion/react";
 import { mobile } from "@service/common/responsive/responsive";
-import { PICK_EVENT_PRIZE_CONTAINER_BREAKPOINT } from "@service/constants/breakpoints";
 import { theme } from "@watermelon-clap/core/src/theme";
 
 export const Container = css`
@@ -9,27 +8,24 @@ export const Container = css`
   ${theme.flex.column}
   text-align: center;
   width: fit-content;
-  width: 350px;
 `;
 
-export const img = css`
-  margin-bottom: 40px;
+export const img = (winner?: boolean) => css`
+  margin-bottom: 10px;
+  width: ${winner ? "300px" : "180px"};
 
-  ${mobile(
-    css`
-      width: 300px;
-      margin-bottom: 20px;
-    `,
-    PICK_EVENT_PRIZE_CONTAINER_BREAKPOINT,
-  )}
+  ${mobile(css`
+    width: ${winner ? "200px" : "140px"};
+    margin-bottom: 20px;
+  `)}
 `;
 
 export const rank = css`
-  font-size: 24px;
+  font-size: 16px;
   margin-bottom: 14px;
 `;
 
 export const name = css`
-  font-size: 32px;
-  width: 280px;
+  font-size: 22px;
+  width: 180px;
 `;

--- a/packages/service/src/components/pickEvent/PrizeContainer/PrizeItem/PrizeItem.tsx
+++ b/packages/service/src/components/pickEvent/PrizeContainer/PrizeItem/PrizeItem.tsx
@@ -4,18 +4,13 @@ interface IPrizeItemProps {
   img: string;
   rank: string;
   name: string;
-  imgSize?: string;
+  winner?: boolean;
 }
 
-export const PrizeItem = ({
-  img,
-  rank,
-  name,
-  imgSize = "300px",
-}: IPrizeItemProps) => {
+export const PrizeItem = ({ img, rank, name, winner }: IPrizeItemProps) => {
   return (
     <div css={style.Container}>
-      <img src={img} width={imgSize} css={style.img} />
+      <img src={img} css={style.img(winner)} />
       <h2 css={style.rank}>{rank}</h2>
       <h1 css={style.name}>{name}</h1>
     </div>

--- a/packages/service/src/constants/breakpoints.ts
+++ b/packages/service/src/constants/breakpoints.ts
@@ -1,3 +1,2 @@
 export const MOBILE_BREAKPOINT = "768px" as const;
 export const GNB_BREAKPOINT = "1200px" as const;
-export const PICK_EVENT_PRIZE_CONTAINER_BREAKPOINT = "1120px" as const;

--- a/packages/service/src/pages/Main/Main.css.ts
+++ b/packages/service/src/pages/Main/Main.css.ts
@@ -1,9 +1,14 @@
 import { css } from "@emotion/react";
+import { mobile } from "@service/common/responsive/responsive";
 
 export const mainBg = css`
   background-image: url("images/common/main-bg.webp");
   background-size: cover;
   padding-bottom: 200px;
+
+  ${mobile(css`
+    padding-bottom: 100px;
+  `)}
 `;
 
 export const eventCardWrap = css`

--- a/packages/service/src/pages/PickEvent/PickEvent.css.ts
+++ b/packages/service/src/pages/PickEvent/PickEvent.css.ts
@@ -19,20 +19,22 @@ export const textWrap = css`
   text-align: center;
 
   h1 {
-    ${theme.font.pcpB82}
-    margin-bottom : 12px;
+    ${theme.font.pcpB}
+    font-size : 62px;
+    margin-bottom: 12px;
     text-shadow: 0 0 40px rgba(255, 255, 255, 0.4);
   }
 
   span {
-    ${theme.font.pcpL32}
-    word-spacing : 2px;
+    ${theme.font.pcpL}
+    font-size : 28px;
+    word-spacing: 2px;
     letter-spacing: 2px;
     -webkit-text-stroke: 2px;
   }
 
   pre {
-    ${theme.font.preM20}
+    ${theme.font.preM18}
     line-height: 24px;
   }
 
@@ -80,11 +82,12 @@ export const termListStyle = css`
 `;
 
 export const btn = css`
-  padding: 30px 110px;
+  padding: 24px 76px;
   border-radius: 20px;
   background-color: ${theme.color.eventBlue};
   color: ${theme.color.white};
-  ${theme.font.preB38}
+  ${theme.font.preB}
+  font-size : 28px;
   cursor: pointer;
   border: none;
   transition: all 0.2s;
@@ -103,7 +106,7 @@ export const btn = css`
 `;
 
 export const termWrap = css`
-  padding: 100px;
+  padding: 200px;
   padding-bottom: 0px;
 
   ${mobile(css`

--- a/packages/service/src/pages/PickEvent/PickEvent.css.ts
+++ b/packages/service/src/pages/PickEvent/PickEvent.css.ts
@@ -81,7 +81,7 @@ export const termListStyle = css`
   `)}
 `;
 
-export const btn = css`
+export const btn = (btnIsInView: boolean) => css`
   padding: 24px 76px;
   border-radius: 20px;
   background-color: ${theme.color.eventBlue};
@@ -93,9 +93,9 @@ export const btn = css`
   transition: all 0.2s;
   margin: 0 auto;
   display: block;
+  z-index: 20;
 
   &:hover {
-    transform: scale(1.02);
     background-color: ${theme.color.eventSkyblue};
   }
 
@@ -103,6 +103,15 @@ export const btn = css`
     font-size: 14px;
     padding: 12px 30px;
   `)}
+
+  ${btnIsInView ||
+  css`
+    position: fixed;
+    bottom: 50px;
+    left: 50%;
+    transform: translate(-50%, 0);
+    box-shadow: 0 0 20px 6px ${theme.color.black};
+  `}
 `;
 
 export const termWrap = css`

--- a/packages/service/src/pages/PickEvent/PickEvent.tsx
+++ b/packages/service/src/pages/PickEvent/PickEvent.tsx
@@ -42,21 +42,23 @@ export const PickEvent = () => {
         <span>당첨자 발표 {textData.winnerDate}</span>
         <pre>{textData.desc}</pre>
       </div>
+      <Space size={!isMobile ? 20 : 50} />
 
-      <Space size={!isMobile ? 200 : 100} />
-      <JoinInfo />
-
-      <Space size={!isMobile ? 200 : 100} />
       <CardCarousel />
+
+      <Space size={!isMobile ? 20 : 10} />
 
       <button css={style.btn} onClick={handleClickPickBtn}>
         지금 바로 뽑기
       </button>
+      <Space size={!isMobile ? 200 : 100} />
 
-      <Space size={!isMobile ? 300 : 100} />
+      <JoinInfo />
+      <Space size={!isMobile ? 100 : 100} />
       <PrizeContainer />
 
-      <Space size={100} />
+      <Space size={30} />
+
       <div css={style.termWrap}>
         <span css={style.termTitleStyle}>{pickEventTermsTitle}</span>
         <ul css={style.termListStyle}>

--- a/packages/service/src/pages/PickEvent/PickEvent.tsx
+++ b/packages/service/src/pages/PickEvent/PickEvent.tsx
@@ -10,11 +10,16 @@ import { css } from "@emotion/react";
 import { Space } from "@service/common/styles/Space";
 import { useMobile } from "@service/common/hooks/useMobile";
 import { apiGetPartsRemain } from "@service/apis/partsEvent/apiGetPartsRemain";
+import { useRef } from "react";
+import { useInView } from "framer-motion";
 
 export const PickEvent = () => {
   const navigate = useNavigate();
   const isMobile = useMobile();
   const { login, getIsLogin } = useAuth();
+
+  const btnRef = useRef(null);
+  const btnIsInView = useInView(btnRef);
 
   const handleClickPickBtn = () => {
     const handleLogin = () => {
@@ -48,7 +53,8 @@ export const PickEvent = () => {
 
       <Space size={!isMobile ? 20 : 10} />
 
-      <button css={style.btn} onClick={handleClickPickBtn}>
+      <div ref={btnRef} />
+      <button css={style.btn(btnIsInView)} onClick={handleClickPickBtn}>
         지금 바로 뽑기
       </button>
       <Space size={!isMobile ? 200 : 100} />


### PR DESCRIPTION
# 🔗 연관된 이슈

- [연관된 이슈 링크](https://watermelon-clap.atlassian.net/browse/CLAP-159)
  
<br/>

# 📗 작업 내용

### 이슈 내용
- 컴포넌트 크기가 너무 커서 한눈에 잘 안 들어오는 이슈가 있었습니다.

### 변경 사항
- 전체적인 컴포넌트 크기 축소, 레이아웃 변경
- `파츠뽑기` 버튼이 화면에서 벗어나는 경우 화면 하단에 고정

<img width="1127" alt="image" src="https://github.com/user-attachments/assets/9365acbc-2ff5-47c1-85ca-5ee1905c653b">

<img width="982" alt="image" src="https://github.com/user-attachments/assets/4fc48132-59c2-4eb6-b44e-b768d2edd724">


<br/>


# ✏️ 리뷰어 멘션

- @DaeWon9 
