### PR TITLE
feat(CLAP-163): 파츠뽑기 클릭 유도 UI 구현

### DIFF
--- a/packages/service/src/components/ClickInduceIcon/ClickInduceIcon.tsx
+++ b/packages/service/src/components/ClickInduceIcon/ClickInduceIcon.tsx
@@ -1,0 +1,48 @@
+import { motion } from "framer-motion";
+import { css } from "@emotion/react";
+import { PiMouseLeftClickFill } from "react-icons/pi";
+import { theme } from "@watermelon-clap/core/src/theme";
+
+export const ClickInduceIcon = () => {
+  return (
+    <motion.div
+      css={css`
+        position: relative;
+        top: 60px;
+        z-index: 2;
+      `}
+      transition={{
+        duration: 0.8,
+        repeat: Infinity,
+        repeatType: "reverse",
+        ease: "easeInOut",
+      }}
+      animate={{
+        y: -100,
+      }}
+    >
+      <div
+        css={[
+          theme.flex.column,
+          css`
+            color: ${theme.color.gray100};
+            gap: 4px;
+            filter: drop-shadow(0px 0px 5px #fff);
+          `,
+        ]}
+      >
+        <PiMouseLeftClickFill size={40} />
+        <h4
+          css={[
+            theme.font.pcpB,
+            css`
+              margin-top: 4px;
+            `,
+          ]}
+        >
+          CLICK
+        </h4>
+      </div>
+    </motion.div>
+  );
+};

--- a/packages/service/src/components/ClickInduceIcon/index.ts
+++ b/packages/service/src/components/ClickInduceIcon/index.ts
@@ -1,0 +1,1 @@
+export { ClickInduceIcon } from "./ClickInduceIcon";

--- a/packages/service/src/components/partsPick/PartsCard/PartsCard.tsx
+++ b/packages/service/src/components/partsPick/PartsCard/PartsCard.tsx
@@ -121,6 +121,7 @@ export const PartsCard = ({
   };
 
   const handleClick = () => {
+    if (isFlipped) return;
     if (remainChance < 0 || !getIsLogin()) return;
 
     if (isFrontShow) {

--- a/packages/service/src/pages/PartsPick/PartsPick.tsx
+++ b/packages/service/src/pages/PartsPick/PartsPick.tsx
@@ -52,6 +52,7 @@ export const PartsPick = () => {
         },
       });
     }
+    setPartsInfo(undefined);
     refetchRemainChance();
   };
 
@@ -91,7 +92,7 @@ export const PartsPick = () => {
           setPartsInfo={setPartsInfo}
         />
 
-        <ClickInduceIcon />
+        {!partsInfo && <ClickInduceIcon />}
 
         <Space size={isMobile ? 4 : 6} />
         {isPickComplete && (

--- a/packages/service/src/pages/PartsPick/PartsPick.tsx
+++ b/packages/service/src/pages/PartsPick/PartsPick.tsx
@@ -17,11 +17,7 @@ import { apiGetLotteryStatus } from "@service/apis/lottery/apiGetLotteryStatus";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { getAccessToken } from "@watermelon-clap/core/src/utils";
 import { IParts } from "@watermelon-clap/core/src/types";
-import { motion } from "framer-motion";
-import { css } from "@emotion/react";
-import { PiMouseLeftClickFill } from "react-icons/pi";
-
-import { theme } from "@watermelon-clap/core/src/theme";
+import { ClickInduceIcon } from "@service/components/ClickInduceIcon";
 
 enum Category {
   REAR = "스포일러",
@@ -94,45 +90,9 @@ export const PartsPick = () => {
           partsInfo={partsInfo}
           setPartsInfo={setPartsInfo}
         />
-        <motion.div
-          css={css`
-            position: relative;
-            top: 60px;
-            z-index: 2;
-          `}
-          transition={{
-            duration: 0.8,
-            repeat: Infinity,
-            repeatType: "reverse",
-            ease: "easeInOut",
-          }}
-          animate={{
-            y: -100,
-          }}
-        >
-          <div
-            css={[
-              theme.flex.column,
-              css`
-                color: ${theme.color.gray100};
-                gap: 4px;
-                filter: drop-shadow(0px 0px 5px #fff);
-              `,
-            ]}
-          >
-            <PiMouseLeftClickFill size={40} />
-            <h4
-              css={[
-                theme.font.pcpB,
-                css`
-                  margin-top: 4px;
-                `,
-              ]}
-            >
-              CLICK
-            </h4>
-          </div>
-        </motion.div>
+
+        <ClickInduceIcon />
+
         <Space size={isMobile ? 4 : 6} />
         {isPickComplete && (
           <p css={partsNameStyle}>

--- a/packages/service/src/pages/PartsPick/PartsPick.tsx
+++ b/packages/service/src/pages/PartsPick/PartsPick.tsx
@@ -17,6 +17,11 @@ import { apiGetLotteryStatus } from "@service/apis/lottery/apiGetLotteryStatus";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { getAccessToken } from "@watermelon-clap/core/src/utils";
 import { IParts } from "@watermelon-clap/core/src/types";
+import { motion } from "framer-motion";
+import { css } from "@emotion/react";
+import { PiMouseLeftClickFill } from "react-icons/pi";
+
+import { theme } from "@watermelon-clap/core/src/theme";
 
 enum Category {
   REAR = "스포일러",
@@ -80,6 +85,7 @@ export const PartsPick = () => {
     <>
       <div css={partsPickBackgroundStyle}>
         <PickTitle />
+
         <PartsCard
           backImage="/images/parts/back.svg"
           isMouseOutAnimationEnabled={false}
@@ -88,6 +94,45 @@ export const PartsPick = () => {
           partsInfo={partsInfo}
           setPartsInfo={setPartsInfo}
         />
+        <motion.div
+          css={css`
+            position: relative;
+            top: 60px;
+            z-index: 2;
+          `}
+          transition={{
+            duration: 0.8,
+            repeat: Infinity,
+            repeatType: "reverse",
+            ease: "easeInOut",
+          }}
+          animate={{
+            y: -100,
+          }}
+        >
+          <div
+            css={[
+              theme.flex.column,
+              css`
+                color: ${theme.color.gray100};
+                gap: 4px;
+                filter: drop-shadow(0px 0px 5px #fff);
+              `,
+            ]}
+          >
+            <PiMouseLeftClickFill size={40} />
+            <h4
+              css={[
+                theme.font.pcpB,
+                css`
+                  margin-top: 4px;
+                `,
+              ]}
+            >
+              CLICK
+            </h4>
+          </div>
+        </motion.div>
         <Space size={isMobile ? 4 : 6} />
         {isPickComplete && (
           <p css={partsNameStyle}>


### PR DESCRIPTION
# 🔗 연관된 이슈

- [연관된 이슈 링크](https://watermelon-clap.atlassian.net/browse/CLAP-163)
  
<br/>

# 📗 작업 내용

### 이슈 내용
- 파츠뽑기 카드를 클릭하지 못하고 헤매는 유저에 대한 UX 개선


### 변경 사항
- 파츠뽑기 카드를 클릭하도록 유도하는 아이콘 구현

https://github.com/user-attachments/assets/786748b4-c88c-4326-9f9d-cc4ded5b9c49


<br/>


# ✏️ 리뷰어 멘션

- @DaeWon9 
