### PR TITLE
feat(CLAP-164): 파츠 컬렉션 커스텀카드 호버 시 파츠정보 노출

### DIFF
--- a/packages/service/src/components/partsCollection/CustomCard/CustomCard.css.ts
+++ b/packages/service/src/components/partsCollection/CustomCard/CustomCard.css.ts
@@ -9,7 +9,6 @@ export const card = css`
   margin: 0 auto;
   position: relative;
   flex-shrink: 0;
-  margin-top: 60px;
 
   ${mobile(css`
     width: 350px;

--- a/packages/service/src/components/partsCollection/CustomCard/CustomCard.tsx
+++ b/packages/service/src/components/partsCollection/CustomCard/CustomCard.tsx
@@ -1,26 +1,27 @@
+import { IParts } from "@watermelon-clap/core/src/types";
 import * as style from "./CustomCard.css";
 
 export interface ICustomCardProps {
-  bgImg?: string;
-  spoilerImg?: string;
-  wheelImg?: string;
-  colorImg?: string;
+  bgParts?: IParts;
+  spoilerParts?: IParts;
+  wheelParts?: IParts;
+  colorParts?: IParts;
 }
 
 export const CustomCard = ({
-  bgImg,
-  spoilerImg,
-  wheelImg,
-  colorImg,
+  bgParts,
+  spoilerParts,
+  wheelParts,
+  colorParts,
 }: ICustomCardProps) => {
   return (
     <div css={style.card}>
       <img css={style.carImg} src="images/partsCollection/defaultCar.svg" />
 
-      {bgImg && <img css={style.bgImg} src={bgImg} />}
-      <img css={style.spoilerImg} src={spoilerImg} />
-      <img css={style.wheelImg} src={wheelImg} />
-      <img css={style.colorImg} src={colorImg} />
+      {bgParts?.imgSrc && <img css={style.bgImg} src={bgParts.imgSrc} />}
+      <img css={style.spoilerImg} src={spoilerParts?.imgSrc} />
+      <img css={style.wheelImg} src={wheelParts?.imgSrc} />
+      <img css={style.colorImg} src={colorParts?.imgSrc} />
     </div>
   );
 };

--- a/packages/service/src/components/partsCollection/PinContainer/Pin/Pin.css.ts
+++ b/packages/service/src/components/partsCollection/PinContainer/Pin/Pin.css.ts
@@ -1,0 +1,89 @@
+import { css } from "@emotion/react";
+import { mobile } from "@service/common/responsive/responsive";
+import { theme } from "@watermelon-clap/core/src/theme";
+
+export const pinContainer = (opacity: number) => css`
+  position: absolute;
+  display: flex;
+  justify-content: center;
+
+  width: 200px;
+  height: fit-content;
+
+  visibility: ${opacity === 1 ? "visible" : "hidden"};
+  opacity: ${opacity};
+  z-index: 60;
+
+  transition: opacity ${opacity === 1 ? "1.5s" : "0.5s"} ease;
+
+  ${mobile(css`
+    width: 100px;
+    height: 200px;
+  `)}
+`;
+
+export const pinItemContainer = css`
+  position: absolute;
+  display: flex;
+  justify-content: center;
+  z-index: 10;
+  top: 0;
+
+  filter: drop-shadow(0 0 2px #fff);
+  border-radius: 10px;
+
+  :hover {
+    filter: drop-shadow(0 0 3px #fff);
+  }
+`;
+
+export const pinItem = css`
+  position: relative;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  z-index: 10;
+  padding: 0.3rem 1rem;
+  cursor: pointer;
+`;
+
+export const pinItemContent = css`
+  z-index: 20;
+  color: ${theme.color.white};
+  ${theme.font.preB16}
+  padding: 2px 4px;
+
+  ${mobile(css`
+    font-size: 12px;
+    padding: 1px 2px;
+  `)}
+`;
+
+export const pinItemBottom = css`
+  position: absolute;
+  bottom: 0;
+  left: 1.125rem;
+  height: 2px;
+  width: calc(100% - 2.25rem);
+
+  background: linear-gradient(
+    to right,
+    rgba(52, 211, 153, 0) 0%,
+    rgba(52, 211, 153, 0.9) 50%,
+    rgba(52, 211, 153, 0) 100%
+  );
+
+  transition: opacity 0.5s;
+  opacity: 1;
+  z-index: 22;
+`;
+
+export const pinLine = css`
+  position: absolute;
+  background: linear-gradient(to bottom, transparent, ${theme.color.white});
+  transform: translateY(14px);
+  width: 1px;
+  height: 100%;
+  z-index: 9;
+  filter: blur(0.5px);
+`;

--- a/packages/service/src/components/partsCollection/PinContainer/Pin/Pin.tsx
+++ b/packages/service/src/components/partsCollection/PinContainer/Pin/Pin.tsx
@@ -1,0 +1,56 @@
+import { motion } from "framer-motion";
+import * as style from "./Pin.css";
+import { WaveCircle } from "./WaveCircle";
+import { SerializedStyles } from "@emotion/react";
+import { useModal } from "@watermelon-clap/core/src/hooks";
+import { IParts } from "@watermelon-clap/core/src/types";
+
+interface PinMarkerProps {
+  parts?: IParts;
+  opacity: number;
+  customCss?: SerializedStyles;
+  imgCss?: SerializedStyles;
+}
+
+export const Pin = ({ parts, opacity, customCss, imgCss }: PinMarkerProps) => {
+  const { openModal } = useModal();
+
+  const handleDescriptionButtonClick = () => {
+    openModal({
+      type: "description",
+      props: {
+        src: parts?.thumbnailImgSrc,
+        name: parts?.name,
+        description: parts?.description,
+      },
+    });
+  };
+
+  return (
+    <motion.div css={[style.pinContainer(opacity), customCss]}>
+      {/* PinItem */}
+      <motion.div
+        whileHover={{ scale: 1.1 }}
+        css={style.pinItemContainer}
+        onClick={handleDescriptionButtonClick}
+      >
+        <div css={style.pinItem}>
+          <img
+            src={
+              parts?.category === "COLOR" || parts?.category === "DRIVE_MODE"
+                ? parts?.imgSrc
+                : parts?.thumbnailImgSrc
+            }
+            alt="파츠 이미지"
+            css={imgCss}
+          />
+          <span css={style.pinItemBottom} />
+        </div>
+      </motion.div>
+      {/* Line */}
+      <motion.div css={style.pinLine} />
+      {/* Circle */}
+      <WaveCircle />
+    </motion.div>
+  );
+};

--- a/packages/service/src/components/partsCollection/PinContainer/Pin/WaveCircle/WaveCircle.css.ts
+++ b/packages/service/src/components/partsCollection/PinContainer/Pin/WaveCircle/WaveCircle.css.ts
@@ -1,0 +1,38 @@
+import { css } from "@emotion/react";
+import { mobile } from "@service/common/responsive/responsive";
+
+export const containerStyle = css`
+  perspective: 1000px;
+  transform: rotateX(75deg) translateZ(0);
+  position: absolute;
+  z-index: 20;
+  bottom: -1rem;
+`;
+
+export const circleStyle = css`
+  position: absolute;
+  height: 6.25rem;
+  width: 6.25rem;
+  border-radius: 50%;
+  background-color: rgba(255, 255, 255, 0.5);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.5);
+
+  ${mobile(css`
+    height: 3.25rem;
+    width: 3.25rem;
+  `)}
+`;
+
+export const animationVariants = {
+  hidden: {
+    opacity: 0,
+    scale: 0,
+    x: "-50%",
+    y: "-50%",
+  },
+  visible: {
+    opacity: [0, 1, 0.5, 0],
+    scale: 1,
+    z: 0,
+  },
+};

--- a/packages/service/src/components/partsCollection/PinContainer/Pin/WaveCircle/WaveCircle.tsx
+++ b/packages/service/src/components/partsCollection/PinContainer/Pin/WaveCircle/WaveCircle.tsx
@@ -1,0 +1,30 @@
+import { motion } from "framer-motion";
+import {
+  animationVariants,
+  circleStyle,
+  containerStyle,
+} from "./WaveCircle.css";
+
+export const WaveCircle = () => {
+  const circleCount = 3; // 생성할 원의 개수
+  const delayIncrement = 2; // delay 증가 값
+
+  return (
+    <div css={containerStyle}>
+      {Array.from({ length: circleCount }).map((_, index) => (
+        <motion.div
+          key={index}
+          initial="hidden"
+          animate="visible"
+          variants={animationVariants}
+          transition={{
+            duration: 6,
+            repeat: Infinity,
+            delay: index * delayIncrement,
+          }}
+          css={circleStyle}
+        />
+      ))}
+    </div>
+  );
+};

--- a/packages/service/src/components/partsCollection/PinContainer/Pin/WaveCircle/index.ts
+++ b/packages/service/src/components/partsCollection/PinContainer/Pin/WaveCircle/index.ts
@@ -1,0 +1,1 @@
+export { WaveCircle } from "./WaveCircle";

--- a/packages/service/src/components/partsCollection/PinContainer/Pin/index.ts
+++ b/packages/service/src/components/partsCollection/PinContainer/Pin/index.ts
@@ -1,0 +1,1 @@
+export { Pin } from "./Pin";

--- a/packages/service/src/components/partsCollection/PinContainer/PinContainer.css.ts
+++ b/packages/service/src/components/partsCollection/PinContainer/PinContainer.css.ts
@@ -1,0 +1,129 @@
+import { css } from "@emotion/react";
+import { mobile } from "@service/common/responsive/responsive";
+import { theme } from "@watermelon-clap/core/src/theme";
+
+export const mainContainer = css`
+  position: relative;
+  width: 100%;
+  height: 100%;
+  ${theme.flex.center}
+`;
+
+export const pivotContainer = css`
+  position: absolute;
+  width: 700px;
+  aspect-ratio: 16 / 9;
+  z-index: 1;
+  padding: 10%;
+
+  ${mobile(css`
+    width: 350px;
+  `)}
+`;
+
+export const perspectiveContainer = css`
+  position: absolute;
+  perspective: 1000px;
+  transform: rotateX(70deg);
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+`;
+
+export const innerContainer = css`
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  display: flex;
+  justify-content: start;
+  align-items: start;
+  transition: all 0.7s;
+`;
+
+export const pinCommonImg = css`
+  width: 180px;
+  margin-bottom: -10px;
+
+  ${mobile(css`
+    width: 100px;
+    margin-bottom: -5px;
+  `)}
+`;
+
+export const pinCommonCustom = css`
+  height: 240px;
+  top: -60px;
+  left: 115px;
+
+  ${mobile(css`
+    height: 122px;
+    top: -40px;
+    left: 52px;
+  `)}
+`;
+
+export const pinBgImg = css`
+  width: 120px;
+  margin-bottom: 10px;
+
+  ${mobile(css`
+    width: 60px;
+    margin-bottom: 5px;
+  `)}
+`;
+
+export const pinBgCustom = css`
+  height: 200px;
+  top: -90px;
+  left: 320px;
+
+  ${mobile(css`
+    height: 94px;
+    top: -50px;
+    left: 168px;
+  `)}
+`;
+
+export const pinWheelImg = css`
+  width: 120px;
+  margin-bottom: 3px;
+
+  ${mobile(css`
+    width: 60px;
+    margin-bottom: 5px;
+  `)}
+`;
+
+export const pinWheelCustom = css`
+  height: 182px;
+  top: 10px;
+  left: 229px;
+
+  ${mobile(css`
+    height: 92px;
+    top: -2px;
+    left: 114px;
+  `)}
+`;
+
+export const pinSpoilerImg = css`
+  width: 130px;
+  margin-bottom: 8px;
+
+  ${mobile(css`
+    width: 70px;
+    margin-bottom: 3px;
+  `)}
+`;
+
+export const pinSpoilerCustom = css`
+  height: 160px;
+  top: 10px;
+  left: 410px;
+
+  ${mobile(css`
+    height: 70px;
+    top: 0px;
+    left: 218px;
+  `)}
+`;

--- a/packages/service/src/components/partsCollection/PinContainer/PinContainer.css.ts
+++ b/packages/service/src/components/partsCollection/PinContainer/PinContainer.css.ts
@@ -80,7 +80,7 @@ export const pinBgCustom = css`
   ${mobile(css`
     height: 94px;
     top: -50px;
-    left: 168px;
+    left: 162px;
   `)}
 `;
 
@@ -100,8 +100,8 @@ export const pinWheelCustom = css`
   left: 229px;
 
   ${mobile(css`
-    height: 92px;
-    top: -2px;
+    height: 100px;
+    top: -10px;
     left: 114px;
   `)}
 `;
@@ -117,13 +117,13 @@ export const pinSpoilerImg = css`
 `;
 
 export const pinSpoilerCustom = css`
-  height: 160px;
-  top: 10px;
+  height: 174px;
+  top: -14px;
   left: 410px;
 
   ${mobile(css`
-    height: 70px;
-    top: 0px;
+    height: 89px;
+    top: -18px;
     left: 218px;
   `)}
 `;

--- a/packages/service/src/components/partsCollection/PinContainer/PinContainer.tsx
+++ b/packages/service/src/components/partsCollection/PinContainer/PinContainer.tsx
@@ -1,0 +1,79 @@
+import React, { useState } from "react";
+import { Pin } from "./Pin";
+import { useMobile } from "@service/common/hooks/useMobile";
+import { ICustomCardProps } from "@service/components/partsCollection/CustomCard/CustomCard";
+import * as styles from "./PinContainer.css";
+
+interface PinContainerProps {
+  children: React.ReactNode;
+  equippedParts: ICustomCardProps | undefined;
+}
+
+export const PinContainer = ({
+  children,
+  equippedParts,
+}: PinContainerProps) => {
+  const [perspectiveOpacity, setPerspectiveOpacity] = useState<number>(0);
+  const [transform, setTransform] = useState<string>(
+    "translate(-50%,-50%) rotateX(0deg) scale(1)",
+  );
+  const isMobile = useMobile();
+
+  const onMouseEnter = () => {
+    setTransform(
+      `translate(-50%,-50%) rotateX(50deg) ${
+        isMobile ? "scale(0.9)" : "scale(0.8)"
+      }`,
+    );
+    setPerspectiveOpacity(1);
+  };
+
+  const onMouseLeave = () => {
+    setTransform("translate(-50%,-50%) rotateX(0deg) scale(1)");
+    setPerspectiveOpacity(0);
+  };
+
+  return (
+    <div css={styles.mainContainer}>
+      <div
+        css={styles.pivotContainer}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+      >
+        <div css={styles.perspectiveContainer}>
+          <div style={{ transform }} css={styles.innerContainer}>
+            {children}
+          </div>
+        </div>
+        {/* 색상 */}
+        <Pin
+          parts={equippedParts?.colorParts}
+          opacity={perspectiveOpacity}
+          imgCss={styles.pinCommonImg}
+          customCss={styles.pinCommonCustom}
+        />
+        {/* 배경 */}
+        <Pin
+          parts={equippedParts?.bgParts}
+          opacity={perspectiveOpacity}
+          imgCss={styles.pinBgImg}
+          customCss={styles.pinBgCustom}
+        />
+        {/* 휠 */}
+        <Pin
+          parts={equippedParts?.wheelParts}
+          opacity={perspectiveOpacity}
+          imgCss={styles.pinWheelImg}
+          customCss={styles.pinWheelCustom}
+        />
+        {/* 스포일러 */}
+        <Pin
+          parts={equippedParts?.spoilerParts}
+          opacity={perspectiveOpacity}
+          imgCss={styles.pinSpoilerImg}
+          customCss={styles.pinSpoilerCustom}
+        />
+      </div>
+    </div>
+  );
+};

--- a/packages/service/src/components/partsCollection/PinContainer/PinContainer.tsx
+++ b/packages/service/src/components/partsCollection/PinContainer/PinContainer.tsx
@@ -46,33 +46,42 @@ export const PinContainer = ({
           </div>
         </div>
         {/* 색상 */}
-        <Pin
-          parts={equippedParts?.colorParts}
-          opacity={perspectiveOpacity}
-          imgCss={styles.pinCommonImg}
-          customCss={styles.pinCommonCustom}
-        />
+
+        {equippedParts?.colorParts && (
+          <Pin
+            parts={equippedParts.colorParts}
+            opacity={perspectiveOpacity}
+            imgCss={styles.pinCommonImg}
+            customCss={styles.pinCommonCustom}
+          />
+        )}
         {/* 배경 */}
-        <Pin
-          parts={equippedParts?.bgParts}
-          opacity={perspectiveOpacity}
-          imgCss={styles.pinBgImg}
-          customCss={styles.pinBgCustom}
-        />
+        {equippedParts?.bgParts && (
+          <Pin
+            parts={equippedParts.bgParts}
+            opacity={perspectiveOpacity}
+            imgCss={styles.pinBgImg}
+            customCss={styles.pinBgCustom}
+          />
+        )}
         {/* 휠 */}
-        <Pin
-          parts={equippedParts?.wheelParts}
-          opacity={perspectiveOpacity}
-          imgCss={styles.pinWheelImg}
-          customCss={styles.pinWheelCustom}
-        />
+        {equippedParts?.wheelParts && (
+          <Pin
+            parts={equippedParts.wheelParts}
+            opacity={perspectiveOpacity}
+            imgCss={styles.pinWheelImg}
+            customCss={styles.pinWheelCustom}
+          />
+        )}
         {/* 스포일러 */}
-        <Pin
-          parts={equippedParts?.spoilerParts}
-          opacity={perspectiveOpacity}
-          imgCss={styles.pinSpoilerImg}
-          customCss={styles.pinSpoilerCustom}
-        />
+        {equippedParts?.spoilerParts && (
+          <Pin
+            parts={equippedParts.spoilerParts}
+            opacity={perspectiveOpacity}
+            imgCss={styles.pinSpoilerImg}
+            customCss={styles.pinSpoilerCustom}
+          />
+        )}
       </div>
     </div>
   );

--- a/packages/service/src/components/partsCollection/PinContainer/index.ts
+++ b/packages/service/src/components/partsCollection/PinContainer/index.ts
@@ -1,0 +1,1 @@
+export { PinContainer } from "./PinContainer";

--- a/packages/service/src/pages/PartsCollection/PartsCollection.css.ts
+++ b/packages/service/src/pages/PartsCollection/PartsCollection.css.ts
@@ -32,6 +32,17 @@ export const partsContainer = css`
   gap: 40px;
 
   ${mobile(css`
-    display: block;
+    ${theme.flex.column}
   `)};
+`;
+
+export const customCardContainer = css`
+  ${theme.flex.center}
+  width: 700px;
+  aspect-ratio: 16 / 9;
+  margin-top: 44px;
+
+  ${mobile(css`
+    width: 350px;
+  `)}
 `;

--- a/packages/service/src/pages/PartsCollection/PartsCollection.tsx
+++ b/packages/service/src/pages/PartsCollection/PartsCollection.tsx
@@ -1,34 +1,21 @@
 import { CustomCard } from "@service/components/partsCollection";
 import * as style from "./PartsCollection.css";
 import { PartsTab } from "@service/components/partsCollection/PartsTab";
-import { useQuery } from "@tanstack/react-query";
 import { apiGetMyParts } from "@service/apis/partsEvent/apiGetMyParts";
 import { useEffect, useState } from "react";
 import { ICustomCardProps } from "@service/components/partsCollection/CustomCard/CustomCard";
-import { useAuth } from "@watermelon-clap/core/src/hooks";
 import { IMyParts } from "@watermelon-clap/core/src/types";
 import { getAccessToken } from "@watermelon-clap/core/src/utils";
 import { PinContainer } from "@service/components/partsCollection/PinContainer";
+import { useSuspenseQuery } from "@tanstack/react-query";
 
 export const PartsCollection = () => {
-  const { getIsLogin, login, handleTokenError } = useAuth();
-
   const [equippedParts, setEquippedParts] = useState<ICustomCardProps>();
 
-  const getPartsData = () =>
-    apiGetMyParts().catch(handleTokenError) as Promise<IMyParts[]>;
-
-  const { data: partsDatas, refetch } = useQuery<IMyParts[]>({
+  const { data: partsDatas, refetch } = useSuspenseQuery<IMyParts[]>({
     queryKey: ["myParts", getAccessToken()],
-    queryFn: getPartsData,
+    queryFn: apiGetMyParts,
   });
-
-  useEffect(() => {
-    getIsLogin() ||
-      login().then(() => {
-        refetch();
-      });
-  }, []);
 
   useEffect(() => {
     setEquippedParts(getEquippedPartsImg(partsDatas));

--- a/packages/service/src/pages/PartsCollection/PartsCollection.tsx
+++ b/packages/service/src/pages/PartsCollection/PartsCollection.tsx
@@ -1,30 +1,48 @@
 import { CustomCard } from "@service/components/partsCollection";
 import * as style from "./PartsCollection.css";
 import { PartsTab } from "@service/components/partsCollection/PartsTab";
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { apiGetMyParts } from "@service/apis/partsEvent/apiGetMyParts";
 import { useEffect, useState } from "react";
 import { ICustomCardProps } from "@service/components/partsCollection/CustomCard/CustomCard";
+import { useAuth } from "@watermelon-clap/core/src/hooks";
 import { IMyParts } from "@watermelon-clap/core/src/types";
 import { getAccessToken } from "@watermelon-clap/core/src/utils";
+import { PinContainer } from "@service/components/partsCollection/PinContainer";
 
 export const PartsCollection = () => {
-  const [equippedPartsImg, setEquippedPartsImg] = useState<ICustomCardProps>();
+  const { getIsLogin, login, handleTokenError } = useAuth();
 
-  const { data: partsDatas, refetch } = useSuspenseQuery<IMyParts[]>({
+  const [equippedParts, setEquippedParts] = useState<ICustomCardProps>();
+
+  const getPartsData = () =>
+    apiGetMyParts().catch(handleTokenError) as Promise<IMyParts[]>;
+
+  const { data: partsDatas, refetch } = useQuery<IMyParts[]>({
     queryKey: ["myParts", getAccessToken()],
-    queryFn: apiGetMyParts,
+    queryFn: getPartsData,
   });
 
   useEffect(() => {
-    setEquippedPartsImg(getEquippedPartsImg(partsDatas));
+    getIsLogin() ||
+      login().then(() => {
+        refetch();
+      });
+  }, []);
+
+  useEffect(() => {
+    setEquippedParts(getEquippedPartsImg(partsDatas));
   }, [partsDatas]);
 
   return (
     <div css={style.mainBg}>
       <h1 css={style.pageTitle}>내 아반떼 N 파츠 컬렉션</h1>
       <div css={style.partsContainer}>
-        <CustomCard {...equippedPartsImg} />
+        <div css={style.customCardContainer}>
+          <PinContainer equippedParts={equippedParts}>
+            <CustomCard {...equippedParts} />
+          </PinContainer>
+        </div>
 
         <PartsTab partsDatas={partsDatas} refetchGetMyParts={refetch} />
       </div>
@@ -33,27 +51,27 @@ export const PartsCollection = () => {
 };
 
 const getEquippedPartsImg = (partsDatas?: IMyParts[]) => {
-  const _equippedPartsImg: ICustomCardProps = {};
+  const _equippedParts: ICustomCardProps = {};
 
   partsDatas?.map((cate) =>
     cate.parts.map((parts) => {
       if (parts.equipped) {
         switch (parts.category) {
           case "DRIVE_MODE":
-            _equippedPartsImg.bgImg = parts.imgSrc;
+            _equippedParts.bgParts = parts;
             break;
           case "COLOR":
-            _equippedPartsImg.colorImg = parts.imgSrc;
+            _equippedParts.colorParts = parts;
             break;
           case "REAR":
-            _equippedPartsImg.spoilerImg = parts.imgSrc;
+            _equippedParts.spoilerParts = parts;
             break;
           case "WHEEL":
-            _equippedPartsImg.wheelImg = parts.imgSrc;
+            _equippedParts.wheelParts = parts;
             break;
         }
       }
     }),
   );
-  return _equippedPartsImg;
+  return _equippedParts;
 };


### PR DESCRIPTION
# 🔗 연관된 이슈

- [연관된 이슈 링크](https://watermelon-clap.atlassian.net/browse/CLAP-164?atlOrigin=eyJpIjoiOTJkYjQ0ZGI0YTNmNGFkM2EzNGM4MjkxYTRhYTI5YjYiLCJwIjoiaiJ9)
  
<br/>

# 📗 작업 내용
사용자가 장착한 파츠정보를, 커스텀카드 호버 시 노출되도록 기능을 추가함.


### 변경 사항
- 커스텀카드 호버시, 장착중인 파츠 정보를 핀으로 노출
- 클릭시, 설명 모달창 오픈
- 모바일뷰 구성

<br/>

https://github.com/user-attachments/assets/1d45b2ef-4db4-4d5d-afea-b8cbce5b3661



# ✏️ 리뷰어 멘션
@thgee 
