### PR TITLE
feat(CLAP-161): 기대평 나중에 쓸 수 있도록 수정

### DIFF
--- a/packages/service/src/apis/expectation/apiGetCheckExpectation.ts
+++ b/packages/service/src/apis/expectation/apiGetCheckExpectation.ts
@@ -1,0 +1,10 @@
+import { customFetch } from "@watermelon-clap/core/src/utils";
+import { IApiGetCheckExpectation } from "./type";
+
+export const apiGetCheckExpectation = (): Promise<IApiGetCheckExpectation> => {
+  return customFetch(`${import.meta.env.VITE_BACK_BASE_URL}/expectations/check`)
+    .then((res) => res.json())
+    .catch((error) => {
+      throw error;
+    });
+};

--- a/packages/service/src/apis/expectation/apiGetCheckExpectation.ts
+++ b/packages/service/src/apis/expectation/apiGetCheckExpectation.ts
@@ -1,8 +1,15 @@
-import { customFetch } from "@watermelon-clap/core/src/utils";
+import { customFetch, getAccessToken } from "@watermelon-clap/core/src/utils";
 import { IApiGetCheckExpectation } from "./type";
 
 export const apiGetCheckExpectation = (): Promise<IApiGetCheckExpectation> => {
-  return customFetch(`${import.meta.env.VITE_BACK_BASE_URL}/expectations/check`)
+  return customFetch(
+    `${import.meta.env.VITE_BACK_BASE_URL}/expectations/check`,
+    {
+      headers: {
+        Authorization: `Bearer ${getAccessToken()}`,
+      },
+    },
+  )
     .then((res) => res.json())
     .catch((error) => {
       throw error;

--- a/packages/service/src/apis/expectation/type.ts
+++ b/packages/service/src/apis/expectation/type.ts
@@ -1,3 +1,7 @@
+export interface IApiGetCheckExpectation {
+  exist: false;
+}
+
 export interface IExpectation {
   uploadDate: string;
   uid: string;

--- a/packages/service/src/pages/LotteryApplyFinish/LotteryApplyFinish.tsx
+++ b/packages/service/src/pages/LotteryApplyFinish/LotteryApplyFinish.tsx
@@ -1,4 +1,4 @@
-import { useLocation, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import * as style from "./LotteryApplyFinish.css";
 import { Button, ButtonVariant } from "@service/common/components/Button";
 import { ClipBoardButton } from "@service/common/components/ClipBoardButton";
@@ -12,6 +12,10 @@ import { apiPostExpectation } from "@service/apis/expectation/apiPostExpectation
 import { useAuth, useModal } from "@watermelon-clap/core/src/hooks";
 import { mobile } from "@service/common/responsive/responsive";
 import { useMobile } from "@service/common/hooks/useMobile";
+import { IApiGetCheckExpectation } from "@service/apis/expectation/type";
+import { apiGetCheckExpectation } from "@service/apis/expectation/apiGetCheckExpectation";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { getAccessToken } from "@watermelon-clap/core/src/utils";
 
 export const LotteryApplyFinish = () => {
   const navigate = useNavigate();
@@ -21,11 +25,14 @@ export const LotteryApplyFinish = () => {
   const [isExpectationNull, setIsExpectationNull] = useState(true);
   const [isPostExpectation, setIsPostExpectation] = useState(false);
   const { handleTokenError } = useAuth();
-
   const { openModal } = useModal();
+
   const {
-    state: { isApplied },
-  } = useLocation();
+    data: { exist: existExpectation },
+  } = useSuspenseQuery<IApiGetCheckExpectation>({
+    queryKey: ["existExpectation", getAccessToken()],
+    queryFn: apiGetCheckExpectation,
+  });
 
   useEffect(() => {
     apiGetMyShareLink()
@@ -52,6 +59,13 @@ export const LotteryApplyFinish = () => {
     event.preventDefault();
     if (!expectation) {
       return;
+    }
+
+    if (existExpectation) {
+      return openModal({
+        type: "alert",
+        props: { content: "이미 기대평을 작성한 유저입니다" },
+      });
     }
 
     apiPostExpectation(expectation)
@@ -129,53 +143,51 @@ export const LotteryApplyFinish = () => {
 
         <Space size={40} />
 
-        {isApplied || (
-          <div
+        <div
+          css={[
+            theme.flex.column,
+            css`
+              align-items: start;
+              gap: 24px;
+            `,
+          ]}
+        >
+          <span css={style.sectionTitle}>
+            새롭게 출시된 아반떼 N에 대한 기대평을 남겨주세요 🥳
+          </span>
+          <span css={theme.font.preM18}>
+            남겨주신 기대평은 홈화면에 노출될 수 있습니다! 최대 50자까지 작성할
+            수 있어요.
+          </span>
+
+          <form
+            onSubmit={handleSubmit}
             css={[
-              theme.flex.column,
-              css`
-                align-items: start;
-                gap: 24px;
-              `,
+              theme.flex.center,
+              theme.gap.gap16,
+              mobile(css`
+                flex-direction: column;
+                width: 100%;
+              `),
             ]}
           >
-            <span css={style.sectionTitle}>
-              새롭게 출시된 아반떼 N에 대한 기대평을 남겨주세요 🥳
-            </span>
-            <span css={theme.font.preM18}>
-              남겨주신 기대평은 홈화면에 노출될 수 있습니다! 최대 50자까지
-              작성할 수 있어요.
-            </span>
-
-            <form
-              onSubmit={handleSubmit}
-              css={[
-                theme.flex.center,
-                theme.gap.gap16,
-                mobile(css`
-                  flex-direction: column;
-                  width: 100%;
-                `),
-              ]}
+            <textarea
+              placeholder="여기에 기대평을 작성해주세요"
+              css={style.expectationInput}
+              value={expectation}
+              onChange={handleChange}
+              disabled={isPostExpectation && true}
+            />
+            <Button
+              type="submit"
+              variant={ButtonVariant.LONG}
+              css={style.applyBtn(isExpectationNull)}
+              disabled={isExpectationNull}
             >
-              <textarea
-                placeholder="여기에 기대평을 작성해주세요"
-                css={style.expectationInput}
-                value={expectation}
-                onChange={handleChange}
-                disabled={isPostExpectation && true}
-              />
-              <Button
-                type="submit"
-                variant={ButtonVariant.LONG}
-                css={style.applyBtn(isExpectationNull)}
-                disabled={isExpectationNull}
-              >
-                제출하기
-              </Button>
-            </form>
-          </div>
-        )}
+              제출하기
+            </Button>
+          </form>
+        </div>
       </section>
 
       <Space size={100} />

--- a/packages/service/src/pages/LotteryApplyFinish/LotteryApplyFinish.tsx
+++ b/packages/service/src/pages/LotteryApplyFinish/LotteryApplyFinish.tsx
@@ -16,7 +16,6 @@ import { IApiGetCheckExpectation } from "@service/apis/expectation/type";
 import { apiGetCheckExpectation } from "@service/apis/expectation/apiGetCheckExpectation";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { getAccessToken } from "@watermelon-clap/core/src/utils";
-import { motion } from "framer-motion";
 
 export const LotteryApplyFinish = () => {
   const navigate = useNavigate();

--- a/packages/service/src/pages/LotteryApplyFinish/LotteryApplyFinish.tsx
+++ b/packages/service/src/pages/LotteryApplyFinish/LotteryApplyFinish.tsx
@@ -16,6 +16,7 @@ import { IApiGetCheckExpectation } from "@service/apis/expectation/type";
 import { apiGetCheckExpectation } from "@service/apis/expectation/apiGetCheckExpectation";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { getAccessToken } from "@watermelon-clap/core/src/utils";
+import { motion } from "framer-motion";
 
 export const LotteryApplyFinish = () => {
   const navigate = useNavigate();
@@ -102,11 +103,13 @@ export const LotteryApplyFinish = () => {
           theme.flex.column,
           css`
             margin: 0 auto;
-            width: 70%;
-            max-width: 1000px;
-            justify-content: start;
+            width: fit-content;
+            justify-content: center;
             align-items: start;
           `,
+          mobile(css`
+            width: 84%;
+          `),
         ]}
       >
         <div
@@ -141,7 +144,7 @@ export const LotteryApplyFinish = () => {
           </div>
         </div>
 
-        <Space size={40} />
+        <Space size={60} />
 
         <div
           css={[

--- a/packages/service/src/pages/PartsPick/PartsPick.tsx
+++ b/packages/service/src/pages/PartsPick/PartsPick.tsx
@@ -13,7 +13,6 @@ import { useMobile } from "@service/common/hooks/useMobile";
 import { useNavigate } from "react-router-dom";
 import { apiGetPartsRemain } from "@service/apis/partsEvent";
 import { LOTTER_APPLY_FINISH_PAGE_ROUTE } from "@service/constants/routes";
-import { apiGetLotteryStatus } from "@service/apis/lottery/apiGetLotteryStatus";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { getAccessToken } from "@watermelon-clap/core/src/utils";
 import { IParts } from "@watermelon-clap/core/src/types";
@@ -62,13 +61,6 @@ export const PartsPick = () => {
     queryFn: apiGetPartsRemain,
   });
 
-  const {
-    data: { applied: isApplied },
-  } = useSuspenseQuery({
-    queryKey: ["isApplied", getAccessToken()],
-    queryFn: apiGetLotteryStatus,
-  });
-
   useEffect(() => {
     if (!initPickFlag.current) {
       handleOneMorePickButtonClick();
@@ -102,9 +94,7 @@ export const PartsPick = () => {
               variant={ButtonVariant.LONG}
               css={partsPickButtonStyle}
               onClick={() => {
-                navigate(LOTTER_APPLY_FINISH_PAGE_ROUTE, {
-                  state: { isApplied: isApplied },
-                });
+                navigate(LOTTER_APPLY_FINISH_PAGE_ROUTE);
               }}
             >
               URL 공유하고 아반떼 N 받으러 가기


### PR DESCRIPTION
# 🔗 연관된 이슈

- [연관된 이슈 링크](https://watermelon-clap.atlassian.net/browse/CLAP-161)
  
<br/>

# 📗 작업 내용


### 변경 사항
- 기대평을 `응모여부 -> 기대평 작성여부` 기준으로 작성할 수 있게 변경함
- 응모완료 페이지 레이아웃 수정

<br/>


# ✏️ 리뷰어 멘션

- @DaeWon9
