### PR TITLE
fix(CLAP-166): 카드뽑기 횟수가 없는 경우에도 뽑히는 이슈

### DIFF
--- a/packages/service/src/common/components/ModalContainer/content/modalContent.tsx
+++ b/packages/service/src/common/components/ModalContainer/content/modalContent.tsx
@@ -54,3 +54,11 @@ export const MODAL_CONTENT_ORDER_EVENT_APPLY_DUPPLICATION = (
     <p>하루에 한 번만 참여할 수 있습니다.</p>
   </div>
 );
+
+export const MODAL_CONTENT_NO_REMAINING_CHANCES = (
+  <div css={[theme.flex.center, theme.flex.column]}>
+    <p>뽑기권이 없습니다.</p>
+    <p>내 컬렉션 링크를 통해 친구를 초대해</p>
+    <p>뽑기권을 추가로 획득해보세요!</p>
+  </div>
+);

--- a/packages/service/src/components/partsPick/PartsCard/PartsCard.tsx
+++ b/packages/service/src/components/partsPick/PartsCard/PartsCard.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from "react";
 import styled from "@emotion/styled";
 import { cardBaseStyles } from "./PartsCard.css";
 import { theme } from "@watermelon-clap/core/src/theme";
-import { useAuth } from "@watermelon-clap/core/src/hooks";
+import { useAuth, useModal } from "@watermelon-clap/core/src/hooks";
 import { IParts } from "@watermelon-clap/core/src/types";
 import { css } from "@emotion/react";
 import {
@@ -10,6 +10,7 @@ import {
   craftSideCannons,
 } from "@service/common/utils/confettiCrafter";
 import { apiPostParts } from "@service/apis/partsEvent";
+import { MODAL_CONTENT_NO_REMAINING_CHANCES } from "@service/common/components/ModalContainer/content/modalContent";
 
 interface CardProps {
   backImage: string;
@@ -63,6 +64,7 @@ export const PartsCard = ({
   const [isFlipped, setIsFlipped] = useState(false);
   const [isFrontShow, setIsFrontShow] = useState(false);
   const { getIsLogin } = useAuth();
+  const { openModal } = useModal();
 
   const handleMouseMove = (e: React.MouseEvent | React.TouchEvent) => {
     const $card = cardRef.current;
@@ -122,8 +124,17 @@ export const PartsCard = ({
 
   const handleClick = () => {
     if (isFlipped) return;
-    if (remainChance < 0 || !getIsLogin()) return;
-
+    if (!getIsLogin()) return;
+    if (remainChance < 1) {
+      openModal({
+        type: "alert",
+        props: {
+          title: "내 아반떼 N 뽑기",
+          content: MODAL_CONTENT_NO_REMAINING_CHANCES,
+        },
+      });
+      return;
+    }
     if (isFrontShow) {
       craftFireworks(1);
       return;
@@ -143,7 +154,6 @@ export const PartsCard = ({
   };
 
   useEffect(() => {
-    if (remainChance < 0) return;
     setIsFlipped(false);
     setIsFrontShow(false);
     setIsPickComplete(false);

--- a/packages/service/src/pages/PartsPick/PartsPick.tsx
+++ b/packages/service/src/pages/PartsPick/PartsPick.tsx
@@ -2,12 +2,11 @@ import { Button, ButtonVariant } from "@service/common/components/Button";
 import {
   partsPickBackgroundStyle,
   partsPickButtonStyle,
-  partsPickModalContentStyle,
   partsNameStyle,
 } from "./PartsPick.css";
 import { PartsCard, PickTitle } from "@service/components/partsPick";
 import { Space } from "@service/common/styles/Space";
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { useModal } from "@watermelon-clap/core/src/hooks";
 import { useMobile } from "@service/common/hooks/useMobile";
 import { useNavigate } from "react-router-dom";
@@ -18,6 +17,7 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { getAccessToken } from "@watermelon-clap/core/src/utils";
 import { IParts } from "@watermelon-clap/core/src/types";
 import { ClickInduceIcon } from "@service/components/ClickInduceIcon";
+import { MODAL_CONTENT_NO_REMAINING_CHANCES } from "@service/common/components/ModalContainer/content/modalContent";
 
 enum Category {
   REAR = "스포일러",
@@ -30,27 +30,21 @@ export const PartsPick = () => {
   const { openModal } = useModal();
   const isMobile = useMobile();
   const [isPickComplete, setIsPickComplete] = useState(false);
-  const initPickFlag = useRef(false);
 
   const [partsInfo, setPartsInfo] = useState<IParts>();
   const navigate = useNavigate();
 
   const handleOneMorePickButtonClick = () => {
-    if (!isPickComplete && !initPickFlag) return;
-    if (remainChance < 1) {
+    if (!isPickComplete) return;
+    if (remainChance - 1 < 1) {
       openModal({
         type: "alert",
         props: {
           title: "내 아반떼 N 뽑기",
-          content: (
-            <div css={partsPickModalContentStyle}>
-              <p>뽑기권이 없습니다.</p>
-              <p>내 컬렉션 링크를 통해 친구를 초대해</p>
-              <p>뽑기권을 추가로 획득해보세요!</p>
-            </div>
-          ),
+          content: MODAL_CONTENT_NO_REMAINING_CHANCES,
         },
       });
+      return;
     }
     setPartsInfo(undefined);
     refetchRemainChance();
@@ -70,13 +64,6 @@ export const PartsPick = () => {
     queryKey: ["isApplied", getAccessToken()],
     queryFn: apiGetLotteryStatus,
   });
-
-  useEffect(() => {
-    if (!initPickFlag.current) {
-      handleOneMorePickButtonClick();
-      initPickFlag.current = true;
-    }
-  }, []);
 
   return (
     <>
@@ -124,7 +111,7 @@ export const PartsPick = () => {
             css={partsPickButtonStyle}
             onClick={handleOneMorePickButtonClick}
           >
-            한 번 더 뽑기 ({remainChance}회)
+            한 번 더 뽑기 ({remainChance > 1 ? remainChance - 1 : 0}회)
           </Button>
         )}
       </div>


### PR DESCRIPTION
# 🔗 연관된 이슈

- [연관된 이슈 링크](https://watermelon-clap.atlassian.net/browse/CLAP-166?atlOrigin=eyJpIjoiZTYzYTM2Mjg4NGNmNDAzN2FhMmUyMTU3MGQ1Y2MzZmEiLCJwIjoiaiJ9)
  
<br/>

# 📗 작업 내용
카드뽑기 이벤트 로직 수정

### 이슈 내용
- 남은 횟수가 없는 경우에도 뽑기이벤트가 진행되던 이슈


### 변경 사항
- 남은 횟수가 0일때, 뽑기 페이지로 들어온 후 카드 클릭 시 -> 안내 모달 출력
- 뽑기 진행도중 남은 횟수가 0이 될 경우 -> 해당 페이지를 유지하며 안내모달 출력

<br/>


# ✏️ 리뷰어 멘션
@thgee 
