### PR TITLE
fix(CLAP-151): 파츠뽑기 API에 `credentials` 속성 추가

### DIFF
--- a/packages/service/src/apis/partsEvent/apiPostParts.ts
+++ b/packages/service/src/apis/partsEvent/apiPostParts.ts
@@ -10,6 +10,7 @@ export const apiPostParts = (): Promise<IParts> =>
       method: "POST",
       headers: {
         Authorization: `Bearer ${getAccessToken()}`,
+        credentials: "include",
       },
     },
   ).then((response) => response.json());


### PR DESCRIPTION
# 🔗 연관된 이슈

- [연관된 이슈 링크](https://watermelon-clap.atlassian.net/browse/CLAP-151)
  
<br/>

# 📗 작업 내용


### 변경 사항
- 서버에 쿠키 전송 가능하도록 파츠뽑기 api에 credentials 속성 추가

<br/>


# ✏️ 리뷰어 멘션

- @DaeWon9 
