### PR TITLE
feat(CLAP-171): 기대평 이미 제출한 유저 기대평 입력란 숨기기

### DIFF
--- a/packages/service/src/pages/LotteryApplyFinish/LotteryApplyFinish.css.ts
+++ b/packages/service/src/pages/LotteryApplyFinish/LotteryApplyFinish.css.ts
@@ -17,12 +17,12 @@ export const mainBg = css`
 export const pageTitle = css`
   text-align: center;
   ${theme.font.pcpB}
-  font-size : calc(50px + 2vw);
+  font-size : calc(30px + 2vw);
   padding-top: 120px;
   color: ${theme.color.white};
 
   ${mobile(css`
-    font-size: calc(20px + 2vw);
+    font-size: calc(30px + 2vw);
     padding: 100px 0 50px 0;
   `)}
 `;

--- a/packages/service/src/pages/LotteryApplyFinish/LotteryApplyFinish.tsx
+++ b/packages/service/src/pages/LotteryApplyFinish/LotteryApplyFinish.tsx
@@ -143,53 +143,57 @@ export const LotteryApplyFinish = () => {
           </div>
         </div>
 
-        <Space size={60} />
+        {existExpectation || (
+          <>
+            <Space size={60} />
 
-        <div
-          css={[
-            theme.flex.column,
-            css`
-              align-items: start;
-              gap: 24px;
-            `,
-          ]}
-        >
-          <span css={style.sectionTitle}>
-            새롭게 출시된 아반떼 N에 대한 기대평을 남겨주세요 🥳
-          </span>
-          <span css={theme.font.preM18}>
-            남겨주신 기대평은 홈화면에 노출될 수 있습니다! 최대 50자까지 작성할
-            수 있어요.
-          </span>
-
-          <form
-            onSubmit={handleSubmit}
-            css={[
-              theme.flex.center,
-              theme.gap.gap16,
-              mobile(css`
-                flex-direction: column;
-                width: 100%;
-              `),
-            ]}
-          >
-            <textarea
-              placeholder="여기에 기대평을 작성해주세요"
-              css={style.expectationInput}
-              value={expectation}
-              onChange={handleChange}
-              disabled={isPostExpectation && true}
-            />
-            <Button
-              type="submit"
-              variant={ButtonVariant.LONG}
-              css={style.applyBtn(isExpectationNull)}
-              disabled={isExpectationNull}
+            <div
+              css={[
+                theme.flex.column,
+                css`
+                  align-items: start;
+                  gap: 24px;
+                `,
+              ]}
             >
-              제출하기
-            </Button>
-          </form>
-        </div>
+              <span css={style.sectionTitle}>
+                새롭게 출시된 아반떼 N에 대한 기대평을 남겨주세요 🥳
+              </span>
+              <span css={theme.font.preM18}>
+                남겨주신 기대평은 홈화면에 노출될 수 있습니다! 최대 50자까지
+                작성할 수 있어요.
+              </span>
+
+              <form
+                onSubmit={handleSubmit}
+                css={[
+                  theme.flex.center,
+                  theme.gap.gap16,
+                  mobile(css`
+                    flex-direction: column;
+                    width: 100%;
+                  `),
+                ]}
+              >
+                <textarea
+                  placeholder="여기에 기대평을 작성해주세요"
+                  css={style.expectationInput}
+                  value={expectation}
+                  onChange={handleChange}
+                  disabled={isPostExpectation && true}
+                />
+                <Button
+                  type="submit"
+                  variant={ButtonVariant.LONG}
+                  css={style.applyBtn(isExpectationNull)}
+                  disabled={isExpectationNull}
+                >
+                  제출하기
+                </Button>
+              </form>
+            </div>
+          </>
+        )}
       </section>
 
       <Space size={100} />


### PR DESCRIPTION
# 🔗 연관된 이슈

- [연관된 이슈 링크](https://watermelon-clap.atlassian.net/browse/CLAP-171)
  
<br/>

# 📗 작업 내용


### 변경 사항
- 기대평을 이미 제출한 유저는 기대평 입력란이 보이지 않도록 하였습니다.

<br/>


# ✏️ 리뷰어 멘션

- @DaeWon9 
