### PR TITLE
fix(CLAP-172): Footer에 `지금바로뽑기` 버튼 안 겹치게 수정

### DIFF
--- a/packages/service/src/pages/PickEvent/PickEvent.css.ts
+++ b/packages/service/src/pages/PickEvent/PickEvent.css.ts
@@ -81,7 +81,7 @@ export const termListStyle = css`
   `)}
 `;
 
-export const btn = (btnIsInView: boolean) => css`
+export const btn = (btnIsInView: boolean, btnEndIsInView: boolean) => css`
   padding: 24px 76px;
   border-radius: 20px;
   background-color: ${theme.color.eventBlue};
@@ -90,7 +90,9 @@ export const btn = (btnIsInView: boolean) => css`
   font-size : 28px;
   cursor: pointer;
   border: none;
-  transition: background-color 0.2s;
+  transition:
+    background-color 0.2s,
+    opacity 0.2s ease-in-out;
   margin: 0 auto;
   display: block;
   z-index: 20;
@@ -111,6 +113,10 @@ export const btn = (btnIsInView: boolean) => css`
     left: 50%;
     transform: translate(-50%, 0);
     box-shadow: 0 0 20px 6px ${theme.color.black};
+  `}
+  ${btnEndIsInView &&
+  css`
+    opacity: 0;
   `}
 `;
 

--- a/packages/service/src/pages/PickEvent/PickEvent.tsx
+++ b/packages/service/src/pages/PickEvent/PickEvent.tsx
@@ -18,6 +18,9 @@ export const PickEvent = () => {
   const btnRef = useRef(null);
   const btnIsInView = useInView(btnRef);
 
+  const btnEndRef = useRef(null);
+  const btnEndIsInView = useInView(btnEndRef);
+
   return (
     <div css={style.bg}>
       <Space size={80} />
@@ -39,10 +42,10 @@ export const PickEvent = () => {
 
       <Space size={!isMobile ? 20 : 10} />
 
-      <div ref={btnRef} />
+      <div className="btn-detect" ref={btnRef} />
 
       <button
-        css={style.btn(btnIsInView)}
+        css={style.btn(btnIsInView, btnEndIsInView)}
         onClick={() => navigate("/parts-pick")}
       >
         지금 바로 뽑기
@@ -63,6 +66,7 @@ export const PickEvent = () => {
           ))}
         </ul>
       </div>
+      <div className="btn-detect" ref={btnEndRef} />
     </div>
   );
 };

--- a/packages/service/src/pages/PickEvent/PickEvent.tsx
+++ b/packages/service/src/pages/PickEvent/PickEvent.tsx
@@ -22,52 +22,54 @@ export const PickEvent = () => {
   const btnEndIsInView = useInView(btnEndRef);
 
   return (
-    <div css={style.bg}>
-      <Space size={80} />
-      <div css={style.textWrap}>
-        <h1>내 아반떼 N 뽑기</h1>
-        <span
-          css={css`
-            color: ${theme.color.eventSkyblue};
-          `}
+    <>
+      <div css={style.bg}>
+        <Space size={80} />
+        <div css={style.textWrap}>
+          <h1>내 아반떼 N 뽑기</h1>
+          <span
+            css={css`
+              color: ${theme.color.eventSkyblue};
+            `}
+          >
+            {textData.period}
+          </span>
+          <span>당첨자 발표 {textData.winnerDate}</span>
+          <pre>{textData.desc}</pre>
+        </div>
+        <Space size={!isMobile ? 20 : 50} />
+
+        <CardCarousel />
+
+        <Space size={!isMobile ? 20 : 10} />
+
+        <div className="btn-detect" ref={btnRef} />
+
+        <button
+          css={style.btn(btnIsInView, btnEndIsInView)}
+          onClick={() => navigate("/parts-pick")}
         >
-          {textData.period}
-        </span>
-        <span>당첨자 발표 {textData.winnerDate}</span>
-        <pre>{textData.desc}</pre>
-      </div>
-      <Space size={!isMobile ? 20 : 50} />
+          지금 바로 뽑기
+        </button>
+        <Space size={!isMobile ? 200 : 100} />
 
-      <CardCarousel />
+        <JoinInfo />
+        <Space size={!isMobile ? 100 : 100} />
+        <PrizeContainer />
 
-      <Space size={!isMobile ? 20 : 10} />
+        <Space size={30} />
 
-      <div className="btn-detect" ref={btnRef} />
-
-      <button
-        css={style.btn(btnIsInView, btnEndIsInView)}
-        onClick={() => navigate("/parts-pick")}
-      >
-        지금 바로 뽑기
-      </button>
-      <Space size={!isMobile ? 200 : 100} />
-
-      <JoinInfo />
-      <Space size={!isMobile ? 100 : 100} />
-      <PrizeContainer />
-
-      <Space size={30} />
-
-      <div css={style.termWrap}>
-        <span css={style.termTitleStyle}>{pickEventTermsTitle}</span>
-        <ul css={style.termListStyle}>
-          {pickEventTerms.map((term, idx) => (
-            <li key={idx}>{term}</li>
-          ))}
-        </ul>
+        <div css={style.termWrap}>
+          <span css={style.termTitleStyle}>{pickEventTermsTitle}</span>
+          <ul css={style.termListStyle}>
+            {pickEventTerms.map((term, idx) => (
+              <li key={idx}>{term}</li>
+            ))}
+          </ul>
+        </div>
       </div>
       <div className="btn-detect" ref={btnEndRef} />
-    </div>
+    </>
   );
 };
 


### PR DESCRIPTION
# 🔗 연관된 이슈

- [연관된 이슈 링크](https://watermelon-clap.atlassian.net/browse/CLAP-172)
  
<br/>

# 📗 작업 내용


### 변경 사항
- Footer에 `지금바로뽑기` 버튼이 겹치는 순간 버튼이 사라지도록 구현하였습니다.


https://github.com/user-attachments/assets/b41b4077-ae52-404f-8f0f-5a37e143fca7



<br/>


# ✏️ 리뷰어 멘션

- @DaeWon9 
