### PR TITLE
fix(CLAP-165): 트레이싱카 경로 오류 수정

### DIFF
--- a/packages/service/src/components/newCar/NewCarInfo/NewCarInfo.tsx
+++ b/packages/service/src/components/newCar/NewCarInfo/NewCarInfo.tsx
@@ -54,7 +54,7 @@ export const NewCarInfo = () => {
           ))}
 
           <Space size={100} />
-          <TracingCar x={scrollYProgress} parentRef={ref} />
+          <TracingCar x={scrollYProgress} imgViewRef={ref} />
           {carInfoImgs.slice(4).map((imgSrc, idx) => (
             <motion.img
               transition={{
@@ -82,7 +82,7 @@ export const NewCarInfo = () => {
               margin-left: 200px;
             `}
           />
-          <TracingCar x={x} parentRef={ref} />s
+          <TracingCar x={x} imgViewRef={carouselRef} screenViewRef={ref} />
           {carInfoImgs.map((imgSrc, idx) => (
             <motion.img
               transition={{
@@ -95,6 +95,11 @@ export const NewCarInfo = () => {
               key={idx}
             />
           ))}
+          <div
+            css={css`
+              margin-right: 200px;
+            `}
+          />
         </motion.div>
       </div>
     </section>

--- a/packages/service/src/components/newCar/TracingCar/TracingCar.css.ts
+++ b/packages/service/src/components/newCar/TracingCar/TracingCar.css.ts
@@ -2,7 +2,7 @@ import { css } from "@emotion/react";
 import { mobile } from "@service/common/responsive/responsive";
 
 export const bodyStyles = css`
-  height: 2000vh;
+  height: 100vh;
   width: 100%;
   position: absolute;
   opacity: 0.6;

--- a/packages/service/src/components/newCar/TracingCar/TracingCar.tsx
+++ b/packages/service/src/components/newCar/TracingCar/TracingCar.tsx
@@ -56,9 +56,6 @@ export const TracingCar = ({
         const curY = x.get();
         const diffY = prevY - curY;
         const offsetY = diffY > 0 ? innerHeight * 0.1 : innerHeight * 0.6;
-
-        console.log(offsetY);
-
         newOffset =
           ((x.get() * pivotHeight + offsetY) / (pivotHeight + offsetY)) * 100;
       } else {

--- a/packages/service/src/components/newCar/TracingCar/TracingCar.tsx
+++ b/packages/service/src/components/newCar/TracingCar/TracingCar.tsx
@@ -11,13 +11,18 @@ import {
 
 interface TracingCarProps {
   x: MotionValue<number>;
-  parentRef: RefObject<HTMLDivElement>;
+  imgViewRef: RefObject<HTMLDivElement>;
+  screenViewRef?: RefObject<HTMLDivElement>;
 }
 
-export const TracingCar = ({ x, parentRef }: TracingCarProps) => {
+export const TracingCar = ({
+  x,
+  imgViewRef,
+  screenViewRef,
+}: TracingCarProps) => {
   const isMobile = useMobile();
-  const [width, setWidth] = useState(0); // pc 일때는 width 가 경로의 세로 길이
-  const [height, setHeight] = useState(0); // pc 일때는 height 가 경로의 가로 길이
+  const [width, setWidth] = useState(0);
+  const [height, setHeight] = useState(0);
   const [offsetDistance, setOffsetDistance] = useState(0);
 
   const pathData = useMemo(() => {
@@ -27,28 +32,48 @@ export const TracingCar = ({ x, parentRef }: TracingCarProps) => {
   }, [isMobile, width, height]);
 
   useEffect(() => {
-    setHeight(parentRef.current?.clientHeight as number);
-    setWidth(parentRef.current?.clientWidth as number);
-  }, [parentRef]);
+    if (isMobile) {
+      setHeight(imgViewRef.current?.clientHeight as number);
+      setWidth(imgViewRef.current?.clientWidth as number);
+    } else {
+      setHeight((imgViewRef.current?.clientWidth as number) - 400);
+      setWidth(screenViewRef?.current?.clientWidth as number);
+    }
+  }, [
+    imgViewRef.current?.clientHeight,
+    imgViewRef.current?.clientWidth,
+    screenViewRef?.current?.clientWidth,
+  ]);
 
   useEffect(() => {
     const updateOffsetDistance = () => {
-      if (isMobile) {
-        const offsetY = 54; // gnb height
+      let newOffset;
 
-        const newOffset =
-          ((Math.abs(x.get()) * height + offsetY) / height) * 100;
-        setOffsetDistance(newOffset);
+      if (isMobile) {
+        const pivotHeight = height - 270;
+        const innerHeight = window.innerHeight;
+        const prevY = x.getPrevious() as number;
+        const curY = x.get();
+        const diffY = prevY - curY;
+        const offsetY = diffY > 0 ? innerHeight * 0.1 : innerHeight * 0.6;
+
+        console.log(offsetY);
+
+        newOffset =
+          ((x.get() * pivotHeight + offsetY) / (pivotHeight + offsetY)) * 100;
       } else {
         const prevX = x.getPrevious() as number;
         const curX = x.get();
         const diffX = prevX - curX;
         const offsetX = diffX > 0 ? width * 0.8 : width * 0.2;
-
-        const newOffset = ((Math.abs(x.get()) + offsetX) / height) * 100;
-
-        setOffsetDistance(newOffset === Infinity ? 0 : newOffset);
+        newOffset = ((Math.abs(x.get()) + offsetX) / height) * 100;
       }
+
+      if (isNaN(newOffset) || !isFinite(newOffset)) {
+        newOffset = 0;
+      }
+
+      setOffsetDistance(newOffset);
     };
 
     const unsubscribe = x.onChange(() => {


### PR DESCRIPTION
# 🔗 연관된 이슈

- [연관된 이슈 링크](https://watermelon-clap.atlassian.net/browse/CLAP-165?atlOrigin=eyJpIjoiMmIyNTMwNDdjNWYyNGY5MGE0YzI0ZmY1ZmFkZGY0M2EiLCJwIjoiaiJ9)
  
<br/>

# 📗 작업 내용
트레이싱카 경로 오류 수정

### 이슈 내용
- 트레이싱카의 경로가 끊기는 이슈
- 지나가지 않은 경로도 지나갔다고 표시되는 이슈
- 모바일에서 경로가 두개가 표시되는 이슈


### 변경 사항
- 경로의 길이 기준을 변경하여 올바른 길이대로 경로가 생성되게 수정
- 계산과정에서 NaN, Infinity 예외처리 추가

<br/>


# ✏️ 리뷰어 멘션
@thgee 
