### PR TITLE
fix(CLAP-176): 로그인 만료 시 타이머 음수 되는 이슈 해결,  로그인 연장 클릭 시 확인 모달 띄우기

### DIFF
--- a/packages/service/src/common/components/GlobalNavigationBar/GlobalNavs/ExpirationTimer/ExpirationTimer.tsx
+++ b/packages/service/src/common/components/GlobalNavigationBar/GlobalNavs/ExpirationTimer/ExpirationTimer.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import * as style from "./ExpirationTimer.css";
 import { PiTimerBold } from "react-icons/pi";
-import { useAuth } from "@watermelon-clap/core/src/hooks";
+import { useAuth, useModal } from "@watermelon-clap/core/src/hooks";
 import { css } from "@emotion/react";
 import { theme } from "@watermelon-clap/core/src/theme";
 
@@ -15,9 +15,20 @@ export const ExpirationTimer = ({ diffMs }: IExpirationTimerProps) => {
   const { refresh, getExpirationTime } = useAuth();
 
   const handleRefreshToken = () => {
-    refresh()?.then(() => setRemainingTime(getExpirationTime() as number));
+    openModal({
+      type: "confirm",
+      props: {
+        title: "로그인",
+        content: "로그인을 연장하시겠습니까?",
+        confirmEvent: () => {
+          refresh()?.then(() =>
+            setRemainingTime(getExpirationTime() as number),
+          );
+        },
+      },
+    });
   };
-
+  const { openModal } = useModal();
   useEffect(() => {
     if (remainingTime <= 0) return;
 
@@ -64,7 +75,7 @@ export const ExpirationTimer = ({ diffMs }: IExpirationTimerProps) => {
           }
         `}
       >
-        갱신
+        연장
       </span>
     </span>
   );

--- a/packages/service/src/common/components/GlobalNavigationBar/GlobalNavs/ExpirationTimer/ExpirationTimer.tsx
+++ b/packages/service/src/common/components/GlobalNavigationBar/GlobalNavs/ExpirationTimer/ExpirationTimer.tsx
@@ -45,9 +45,13 @@ export const ExpirationTimer = ({ diffMs }: IExpirationTimerProps) => {
   return (
     <span css={style.timer}>
       <PiTimerBold />
-      <div>
-        {diffMins} : {diffSecs}
-      </div>
+      {remainingTime <= 0 ? (
+        <div>로그인 만료</div>
+      ) : (
+        <div>
+          {diffMins} : {diffSecs}
+        </div>
+      )}
       |
       <span
         onClick={handleRefreshToken}

--- a/packages/service/src/common/components/GlobalNavigationBar/GlobalNavs/ExpirationTimer/ExpirationTimer.tsx
+++ b/packages/service/src/common/components/GlobalNavigationBar/GlobalNavs/ExpirationTimer/ExpirationTimer.tsx
@@ -3,6 +3,7 @@ import * as style from "./ExpirationTimer.css";
 import { PiTimerBold } from "react-icons/pi";
 import { useAuth } from "@watermelon-clap/core/src/hooks";
 import { css } from "@emotion/react";
+import { theme } from "@watermelon-clap/core/src/theme";
 
 interface IExpirationTimerProps {
   diffMs: number;
@@ -57,6 +58,10 @@ export const ExpirationTimer = ({ diffMs }: IExpirationTimerProps) => {
         onClick={handleRefreshToken}
         css={css`
           cursor: pointer;
+          transition: all 0.2s;
+          :hover {
+            color: ${theme.color.gray200};
+          }
         `}
       >
         갱신


### PR DESCRIPTION
# 🔗 연관된 이슈

- [연관된 이슈 링크](https://watermelon-clap.atlassian.net/browse/CLAP-176)
  
<br/>

# 📗 작업 내용

### 이슈 내용
- 로그인 만료 시 타이머 음수 되는 이슈


### 변경 사항
- 로그인 만료 시 `로그인 만료` 문구 띄우기
- 로그인 연장 클릭 시 확인 모달 띄우기

<img width="252" alt="image" src="https://github.com/user-attachments/assets/2c32be86-952d-490c-896b-829706404539">


<br/>


# ✏️ 리뷰어 멘션

- @DaeWon9 
