### PR TITLE
feat(CLAP-181): 모바일뷰에서 핀컨테이너 터치이벤트 추가

### DIFF
--- a/packages/service/src/apis/partsEvent/apiPatchMyParts.ts
+++ b/packages/service/src/apis/partsEvent/apiPatchMyParts.ts
@@ -9,5 +9,5 @@ export const apiPatchMyParts = (token: string, partsId: number) => {
         Authorization: `Bearer ${token}`,
       },
     },
-  ).then(() => console.log(partsId));
+  );
 };

--- a/packages/service/src/components/partsCollection/PinContainer/Pin/Pin.css.ts
+++ b/packages/service/src/components/partsCollection/PinContainer/Pin/Pin.css.ts
@@ -78,12 +78,20 @@ export const pinItemBottom = css`
   z-index: 22;
 `;
 
-export const pinLine = css`
+export const pinLineContainer = css`
   position: absolute;
+  width: 100px;
+  height: 100%;
+`;
+
+export const pinLine = css`
+  position: relative;
   background: linear-gradient(to bottom, transparent, ${theme.color.white});
   transform: translateY(14px);
   width: 1px;
   height: 100%;
   z-index: 9;
+  left: 50px;
+
   filter: blur(0.5px);
 `;

--- a/packages/service/src/components/partsCollection/PinContainer/Pin/Pin.tsx
+++ b/packages/service/src/components/partsCollection/PinContainer/Pin/Pin.tsx
@@ -8,22 +8,30 @@ import { IParts } from "@watermelon-clap/core/src/types";
 interface PinMarkerProps {
   parts?: IParts;
   opacity: number;
+  handleOnTouchEnd: (event: React.TouchEvent<HTMLDivElement>) => void;
   customCss?: SerializedStyles;
   imgCss?: SerializedStyles;
 }
 
-export const Pin = ({ parts, opacity, customCss, imgCss }: PinMarkerProps) => {
+export const Pin = ({
+  parts,
+  opacity,
+  handleOnTouchEnd,
+  customCss,
+  imgCss,
+}: PinMarkerProps) => {
   const { openModal } = useModal();
 
   const handleDescriptionButtonClick = () => {
-    openModal({
-      type: "description",
-      props: {
-        src: parts?.thumbnailImgSrc,
-        name: parts?.name,
-        description: parts?.description,
-      },
-    });
+    opacity === 1 &&
+      openModal({
+        type: "description",
+        props: {
+          src: parts?.thumbnailImgSrc,
+          name: parts?.name,
+          description: parts?.description,
+        },
+      });
   };
 
   return (
@@ -48,7 +56,12 @@ export const Pin = ({ parts, opacity, customCss, imgCss }: PinMarkerProps) => {
         </div>
       </motion.div>
       {/* Line */}
-      <motion.div css={style.pinLine} />
+      <motion.div
+        css={style.pinLineContainer}
+        onTouchEnd={(event) => handleOnTouchEnd(event)}
+      >
+        <motion.div css={style.pinLine} />
+      </motion.div>
       {/* Circle */}
       <WaveCircle />
     </motion.div>

--- a/packages/service/src/components/partsCollection/PinContainer/Pin/Pin.tsx
+++ b/packages/service/src/components/partsCollection/PinContainer/Pin/Pin.tsx
@@ -63,7 +63,9 @@ export const Pin = ({
         <motion.div css={style.pinLine} />
       </motion.div>
       {/* Circle */}
-      <WaveCircle />
+      <motion.div onTouchEnd={(event) => handleOnTouchEnd(event)}>
+        <WaveCircle />
+      </motion.div>
     </motion.div>
   );
 };

--- a/packages/service/src/components/partsCollection/PinContainer/PinContainer.tsx
+++ b/packages/service/src/components/partsCollection/PinContainer/PinContainer.tsx
@@ -34,12 +34,18 @@ export const PinContainer = ({
     setPerspectiveOpacity(0);
   };
 
+  const handleOnTouchEnd = () => {
+    if (perspectiveOpacity === 1) onMouseLeave();
+    else onMouseEnter();
+  };
+
   return (
     <div css={styles.mainContainer}>
       <div
         css={styles.pivotContainer}
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
+        onTouchEnd={handleOnTouchEnd}
       >
         <div css={styles.perspectiveContainer}>
           <div style={{ transform }} css={styles.innerContainer}>

--- a/packages/service/src/components/partsCollection/PinContainer/PinContainer.tsx
+++ b/packages/service/src/components/partsCollection/PinContainer/PinContainer.tsx
@@ -34,7 +34,10 @@ export const PinContainer = ({
     setPerspectiveOpacity(0);
   };
 
-  const handleOnTouchEnd = () => {
+  const handleOnTouchEnd = (event: React.TouchEvent<HTMLDivElement>) => {
+    event.stopPropagation();
+    event.preventDefault();
+
     if (perspectiveOpacity === 1) onMouseLeave();
     else onMouseEnter();
   };
@@ -45,9 +48,11 @@ export const PinContainer = ({
         css={styles.pivotContainer}
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
-        onTouchEnd={handleOnTouchEnd}
       >
-        <div css={styles.perspectiveContainer}>
+        <div
+          css={styles.perspectiveContainer}
+          onTouchEnd={(event) => handleOnTouchEnd(event)}
+        >
           <div style={{ transform }} css={styles.innerContainer}>
             {children}
           </div>
@@ -58,6 +63,7 @@ export const PinContainer = ({
           <Pin
             parts={equippedParts.colorParts}
             opacity={perspectiveOpacity}
+            handleOnTouchEnd={handleOnTouchEnd}
             imgCss={styles.pinCommonImg}
             customCss={styles.pinCommonCustom}
           />
@@ -67,6 +73,7 @@ export const PinContainer = ({
           <Pin
             parts={equippedParts.bgParts}
             opacity={perspectiveOpacity}
+            handleOnTouchEnd={handleOnTouchEnd}
             imgCss={styles.pinBgImg}
             customCss={styles.pinBgCustom}
           />
@@ -76,6 +83,7 @@ export const PinContainer = ({
           <Pin
             parts={equippedParts.wheelParts}
             opacity={perspectiveOpacity}
+            handleOnTouchEnd={handleOnTouchEnd}
             imgCss={styles.pinWheelImg}
             customCss={styles.pinWheelCustom}
           />
@@ -85,6 +93,7 @@ export const PinContainer = ({
           <Pin
             parts={equippedParts.spoilerParts}
             opacity={perspectiveOpacity}
+            handleOnTouchEnd={handleOnTouchEnd}
             imgCss={styles.pinSpoilerImg}
             customCss={styles.pinSpoilerCustom}
           />


### PR DESCRIPTION
# 🔗 연관된 이슈

- [연관된 이슈 링크](https://watermelon-clap.atlassian.net/browse/CLAP-181?atlOrigin=eyJpIjoiMTNjMmJjMWY5NjViNDc4Mzk2OGU4NWZiYjE3ODlmMDkiLCJwIjoiaiJ9)
  
<br/>

# 📗 작업 내용
모바일뷰에서 핀컨테이너의 작동 로직 추가

### 이슈 내용
- 모바일뷰에서는 호버 이벤트의 부재로 핀컨테이너의 작동이 부자연스러운 이슈
- 핀이 노출되지 않았을때도, 핀의 위치를 터치했을때, 정보를 보여주는 모달이 노출되던 이슈
- 핀의 카드이미지보다 앞에 존재하여 카드위의 핀을 터치했을떄, 핀컨테이너의 상태가 바뀌지 않는 이슈


### 변경 사항
- 모바일 뷰에서 핀컨테이너를 터치하는 이벤트를 감지하여  핀 컨테이너의 상태가 바뀌도록 추가
- 이벤트 전파를 막아 핀컨테이너를 클릭해도 내부의 핀요소까지 이벤트가 전파되는 것을 방지
- 핀의 Line, WaveCircle에 해당하는 부분에 터치이벤트를 감지하여 핀 컨테이너의 상태가 바뀌도록 추가

https://github.com/user-attachments/assets/7772d6a8-8f03-4603-b1c1-33b4b54e7ca6


<br/>


# ✏️ 리뷰어 멘션
- @thgee 
