### PR TITLE
hotfix: GNB 스타일링, 이미지 크기조절, 각종 UX 개선

### DIFF
--- a/packages/service/src/common/components/CheckBox/CheckBox.css.ts
+++ b/packages/service/src/common/components/CheckBox/CheckBox.css.ts
@@ -52,6 +52,7 @@ export const checkBoxLabelStyle = css`
   color: ${theme.color.gray300};
   margin-left: 8px;
   transition: color 0.3s ease-out;
+  cursor: pointer;
 
   ${mobile(css`
     font-size: 14px;

--- a/packages/service/src/common/components/CheckBox/CheckBox.tsx
+++ b/packages/service/src/common/components/CheckBox/CheckBox.tsx
@@ -49,11 +49,12 @@ export const CheckBox = ({
   ...props
 }: CheckBoxProps) => {
   return (
-    <div css={checkBoxContainerStyle} {...props}>
-      <button
-        css={checkBoxButtonStyle}
-        onClick={() => setIsChecked(!isChecked)}
-      >
+    <div
+      css={checkBoxContainerStyle}
+      {...props}
+      onClick={() => setIsChecked(!isChecked)}
+    >
+      <button css={checkBoxButtonStyle}>
         <div
           css={[
             checkBoxStyle(isChecked),

--- a/packages/service/src/common/components/ClickInduceIcon/ClickInduceIcon.tsx
+++ b/packages/service/src/common/components/ClickInduceIcon/ClickInduceIcon.tsx
@@ -1,5 +1,5 @@
 import { motion } from "framer-motion";
-import { css } from "@emotion/react";
+import { css, SerializedStyles } from "@emotion/react";
 import { PiMouseLeftClickFill } from "react-icons/pi";
 import { theme } from "@watermelon-clap/core/src/theme";
 import { mobile } from "@service/common/responsive/responsive";
@@ -7,9 +7,10 @@ import { useMobile } from "@service/common/hooks/useMobile";
 
 export interface ClickInduceIconProps {
   text: string;
+  customCss?: SerializedStyles;
 }
 
-export const ClickInduceIcon = ({ text }: ClickInduceIconProps) => {
+export const ClickInduceIcon = ({ text, customCss }: ClickInduceIconProps) => {
   const isMobile = useMobile();
   return (
     <motion.div
@@ -21,6 +22,8 @@ export const ClickInduceIcon = ({ text }: ClickInduceIconProps) => {
         ${mobile(css`
           top: 20px;
         `)}
+
+        ${customCss};
       `}
       transition={{
         duration: 0.8,

--- a/packages/service/src/common/components/GlobalNavigationBar/GlobalNavs/ExpirationTimer/ExpirationTimer.css.ts
+++ b/packages/service/src/common/components/GlobalNavigationBar/GlobalNavs/ExpirationTimer/ExpirationTimer.css.ts
@@ -18,4 +18,5 @@ export const timer = css`
   display: flex;
   flex-shrink: 0;
   flex-wrap: nowrap;
+  min-width: 170px;
 `;

--- a/packages/service/src/common/components/GlobalNavigationBar/GlobalNavs/ExpirationTimer/ExpirationTimer.tsx
+++ b/packages/service/src/common/components/GlobalNavigationBar/GlobalNavs/ExpirationTimer/ExpirationTimer.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import * as style from "./ExpirationTimer.css";
 import { PiTimerBold } from "react-icons/pi";
-import { useAuth, useModal } from "@watermelon-clap/core/src/hooks";
+import { useAuth } from "@watermelon-clap/core/src/hooks";
 import { css } from "@emotion/react";
 import { theme } from "@watermelon-clap/core/src/theme";
 
@@ -15,20 +15,8 @@ export const ExpirationTimer = ({ diffMs }: IExpirationTimerProps) => {
   const { refresh, getExpirationTime } = useAuth();
 
   const handleRefreshToken = () => {
-    openModal({
-      type: "confirm",
-      props: {
-        title: "로그인",
-        content: "로그인을 연장하시겠습니까?",
-        confirmEvent: () => {
-          refresh()?.then(() =>
-            setRemainingTime(getExpirationTime() as number),
-          );
-        },
-      },
-    });
+    refresh()?.then(() => setRemainingTime(getExpirationTime() as number));
   };
-  const { openModal } = useModal();
   useEffect(() => {
     if (remainingTime <= 0) return;
 

--- a/packages/service/src/common/components/GlobalNavigationBar/GlobalNavs/GlobalNavs.css.ts
+++ b/packages/service/src/common/components/GlobalNavigationBar/GlobalNavs/GlobalNavs.css.ts
@@ -46,10 +46,7 @@ export const linkStyles = css`
   cursor: pointer;
 
   &:hover {
-    transform: translateY(-1px);
-  }
-  &:active {
-    transform: translateY(1px);
+    color: ${theme.color.gray200};
   }
 
   ${mobile(
@@ -76,4 +73,21 @@ export const linkStyles = css`
     `,
     GNB_BREAKPOINT,
   )}
+`;
+
+export const activeLinkStyles = css`
+  position: relative;
+
+  &::after {
+    content: "";
+    position: absolute;
+    display: inline-block;
+    left: 0;
+    bottom: -22px;
+    width: 100%;
+    height: 4px;
+    background-color: white;
+    border-radius: 1px;
+    transition: all 1s;
+  }
 `;

--- a/packages/service/src/common/components/GlobalNavigationBar/GlobalNavs/GlobalNavs.css.ts
+++ b/packages/service/src/common/components/GlobalNavigationBar/GlobalNavs/GlobalNavs.css.ts
@@ -88,6 +88,11 @@ export const activeLinkStyles = css`
     height: 4px;
     background-color: white;
     border-radius: 1px;
-    transition: all 1s;
   }
+
+  ${mobile(css`
+    &::after {
+      display: none;
+    }
+  `)}
 `;

--- a/packages/service/src/common/components/GlobalNavigationBar/GlobalNavs/GlobalNavs.tsx
+++ b/packages/service/src/common/components/GlobalNavigationBar/GlobalNavs/GlobalNavs.tsx
@@ -1,6 +1,11 @@
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import { ReactComponent as NLogo } from "public/images/gnb/n-logo.svg";
-import { linkStyles, navsContainerStyles, nLogoStyles } from "./GlobalNavs.css";
+import {
+  linkStyles,
+  navsContainerStyles,
+  nLogoStyles,
+  activeLinkStyles,
+} from "./GlobalNavs.css";
 import { useErrorBoundary } from "react-error-boundary";
 import {
   NEW_CAR_PAGE_ROUTE,
@@ -23,6 +28,7 @@ interface IGlobalNavsProps {
 
 const GlobalNavs = ({ isOpen, setIsOpen }: IGlobalNavsProps) => {
   const navigate = useNavigate();
+  const location = useLocation();
   const { resetBoundary } = useErrorBoundary();
   const { getExpirationTime, getIsLogin } = useAuth();
 
@@ -51,22 +57,33 @@ const GlobalNavs = ({ isOpen, setIsOpen }: IGlobalNavsProps) => {
     });
   };
 
+  const isActiveRoute = (route: string) => location.pathname === route;
+
   return (
     <div css={navsContainerStyles(isOpen)}>
       <div
-        css={linkStyles}
+        css={[
+          linkStyles,
+          isActiveRoute(NEW_CAR_PAGE_ROUTE) && activeLinkStyles,
+        ]}
         onClick={() => handleNavigation(NEW_CAR_PAGE_ROUTE)}
       >
         아반떼 N 소개
       </div>
       <div
-        css={linkStyles}
+        css={[
+          linkStyles,
+          isActiveRoute(PICK_EVENT_PAGE_ROUTE) && activeLinkStyles,
+        ]}
         onClick={() => handleNavigation(PICK_EVENT_PAGE_ROUTE)}
       >
         내 아반떼 N 뽑기
       </div>
       <div
-        css={linkStyles}
+        css={[
+          linkStyles,
+          isActiveRoute(N_QUIZ_EVENT_PAGE_ROUTE) && activeLinkStyles,
+        ]}
         onClick={() => handleNavigation(N_QUIZ_EVENT_PAGE_ROUTE)}
       >
         <NLogo css={nLogoStyles} /> 퀴즈
@@ -74,13 +91,19 @@ const GlobalNavs = ({ isOpen, setIsOpen }: IGlobalNavsProps) => {
       {isLogin && (
         <>
           <div
-            css={linkStyles}
+            css={[
+              linkStyles,
+              isActiveRoute(PARTS_COLLECTION_PAGE_ROUTE) && activeLinkStyles,
+            ]}
             onClick={() => handleNavigation(PARTS_COLLECTION_PAGE_ROUTE)}
           >
             내 컬렉션
           </div>
           <div
-            css={linkStyles}
+            css={[
+              linkStyles,
+              isActiveRoute(LOTTER_APPLY_INFO_PAGE_ROUTE) && activeLinkStyles,
+            ]}
             onClick={() => handleNavigation(LOTTER_APPLY_INFO_PAGE_ROUTE)}
           >
             기대평 / 공유

--- a/packages/service/src/components/main/Banner/Banner.css.ts
+++ b/packages/service/src/components/main/Banner/Banner.css.ts
@@ -19,6 +19,12 @@ export const bannerImg = ({ index, currentIndex }: IBannerImg) => css`
   opacity: ${index === currentIndex ? 1 : 0};
   transition: opacity 1s ease-in-out;
   position: absolute;
+  height: 100vh;
+  object-fit: cover;
+
+  ${mobile(css`
+    height: fit-content;
+  `)}
 `;
 
 export const bannerContent = css`

--- a/packages/service/src/components/main/EventPeriod/EventPeriod.css.ts
+++ b/packages/service/src/components/main/EventPeriod/EventPeriod.css.ts
@@ -5,9 +5,9 @@ import { theme } from "@watermelon-clap/core/src/theme";
 export const container = css`
   color: ${theme.color.white};
   text-align: center;
-  padding-top: 70px;
+  padding-top: 150px;
   ${mobile(css`
-    padding-top: 30px;
+    padding-top: 50px;
   `)}
 `;
 

--- a/packages/service/src/components/main/EventPeriod/EventPeriod.tsx
+++ b/packages/service/src/components/main/EventPeriod/EventPeriod.tsx
@@ -1,14 +1,12 @@
 import * as style from "./EventPeriod.css";
 import { theme } from "@watermelon-clap/core/src/theme";
 import { Timer } from "./Timer";
-import { Space } from "@service/common/styles/Space";
 
 export const EventPeriod = () => {
   const endData = new Date("2024/09/08 23:59:59");
 
   return (
     <div css={style.container}>
-      <Space size={150} />
       <h1 css={style.title}>아반떼 N 출시 기념 이벤트</h1>
       <h2 css={style.period}>2024. 08. 19 ~ 09. 08</h2>
       <div css={theme.margin.mg24}></div>

--- a/packages/service/src/components/main/EventPeriod/EventPeriod.tsx
+++ b/packages/service/src/components/main/EventPeriod/EventPeriod.tsx
@@ -1,12 +1,14 @@
 import * as style from "./EventPeriod.css";
 import { theme } from "@watermelon-clap/core/src/theme";
 import { Timer } from "./Timer";
+import { Space } from "@service/common/styles/Space";
 
 export const EventPeriod = () => {
   const endData = new Date("2024/09/08 23:59:59");
 
   return (
     <div css={style.container}>
+      <Space size={150} />
       <h1 css={style.title}>아반떼 N 출시 기념 이벤트</h1>
       <h2 css={style.period}>2024. 08. 19 ~ 09. 08</h2>
       <div css={theme.margin.mg24}></div>

--- a/packages/service/src/components/pickEvent/CardCarousel/CardCarousel.css.ts
+++ b/packages/service/src/components/pickEvent/CardCarousel/CardCarousel.css.ts
@@ -32,7 +32,6 @@ export const sliderContainer = css`
 export const cardWrap = css``;
 
 export const cardItem = css`
-  cursor: pointer;
   transition: all 0.2s;
 
   :hover {

--- a/packages/service/src/components/pickEvent/CardCarousel/CardCarousel.tsx
+++ b/packages/service/src/components/pickEvent/CardCarousel/CardCarousel.tsx
@@ -11,9 +11,10 @@ export const CardCarousel = () => {
     slidesToScroll: 1,
     initialSlide: 0,
     autoplay: true,
-    autoplaySpeed: 1500,
+    autoplaySpeed: 1200,
     arrows: false,
     draggable: false,
+    pauseOnHover: false,
 
     responsive: [
       {

--- a/packages/service/src/pages/Main/Main.tsx
+++ b/packages/service/src/pages/Main/Main.tsx
@@ -20,12 +20,14 @@ export const Main = () => {
 
       <Banner />
       <div css={style.mainBg}>
-        <ClickInduceIcon
-          text={"SCROLL"}
-          customCss={css`
-            top: -100px;
-          `}
-        />
+        {isMobile || (
+          <ClickInduceIcon
+            text={"SCROLL"}
+            customCss={css`
+              top: -100px;
+            `}
+          />
+        )}
         <EventPeriod />
         <Space size={isMobile ? 30 : 100} />
         <Expectations />

--- a/packages/service/src/pages/Main/Main.tsx
+++ b/packages/service/src/pages/Main/Main.tsx
@@ -5,6 +5,8 @@ import { eventData } from "./eventData";
 import { Space } from "@service/common/styles/Space";
 import { useMobile } from "@service/common/hooks/useMobile";
 import { Helmet } from "react-helmet";
+import { ClickInduceIcon } from "@service/common/components/ClickInduceIcon";
+import { css } from "@emotion/react";
 
 export const Main = () => {
   const isMobile = useMobile();
@@ -18,6 +20,12 @@ export const Main = () => {
 
       <Banner />
       <div css={style.mainBg}>
+        <ClickInduceIcon
+          text={"SCROLL"}
+          customCss={css`
+            top: -100px;
+          `}
+        />
         <EventPeriod />
         <Space size={isMobile ? 30 : 100} />
         <Expectations />

--- a/packages/service/src/pages/NewCar/NewCar.css.ts
+++ b/packages/service/src/pages/NewCar/NewCar.css.ts
@@ -1,4 +1,5 @@
 import { css } from "@emotion/react";
+import { mobile } from "@service/common/responsive/responsive";
 import { theme } from "@watermelon-clap/core/src/theme";
 
 export const bg = css`
@@ -8,4 +9,10 @@ export const bg = css`
 export const mainImg = css`
   width: 100%;
   vertical-align: bottom;
+  height: 100vh;
+  object-fit: cover;
+
+  ${mobile(css`
+    height: fit-content;
+  `)}
 `;

--- a/packages/service/src/pages/NewCar/NewCar.tsx
+++ b/packages/service/src/pages/NewCar/NewCar.tsx
@@ -6,6 +6,7 @@ import { css } from "@emotion/react";
 import { useMobile } from "@service/common/hooks/useMobile";
 
 export const NewCar = () => {
+  const isMobile = useMobile();
   return (
     <>
       <Helmet>
@@ -16,12 +17,14 @@ export const NewCar = () => {
       </Helmet>
       <div css={style.bg}>
         <img src="images/newCar/new-car-main-img.webp" css={style.mainImg} />
-        <ClickInduceIcon
-          text={"SCROLL"}
-          customCss={css`
-            top: -100px;
-          `}
-        />
+        {isMobile || (
+          <ClickInduceIcon
+            text={"SCROLL"}
+            customCss={css`
+              top: -100px;
+            `}
+          />
+        )}
         <NewCarInfo />
       </div>
     </>

--- a/packages/service/src/pages/NewCar/NewCar.tsx
+++ b/packages/service/src/pages/NewCar/NewCar.tsx
@@ -1,6 +1,9 @@
 import { NewCarInfo } from "@service/components/newCar";
 import * as style from "./NewCar.css";
 import { Helmet } from "react-helmet";
+import { ClickInduceIcon } from "@service/common/components/ClickInduceIcon";
+import { css } from "@emotion/react";
+import { useMobile } from "@service/common/hooks/useMobile";
 
 export const NewCar = () => {
   return (
@@ -13,6 +16,12 @@ export const NewCar = () => {
       </Helmet>
       <div css={style.bg}>
         <img src="images/newCar/new-car-main-img.webp" css={style.mainImg} />
+        <ClickInduceIcon
+          text={"SCROLL"}
+          customCss={css`
+            top: -100px;
+          `}
+        />
         <NewCarInfo />
       </div>
     </>


### PR DESCRIPTION

# 📗 작업 내용



### 변경 사항
- `GNB`에 현재 페이지에 따라 밑줄표시
- 로그인 타이머 `width` 고정 
- 로그인 연장시 뜨던 모달 삭제
- 메인배너 화면에 꽉 차도록 수정
- 배너이미지 아래에 스크롤 유도 아이콘 렌더링

<br/>


# ✏️ 리뷰어 멘션

- @DaeWon9 
