### PR TITLE
chore: og:title 변경

### DIFF
--- a/packages/service/index.html
+++ b/packages/service/index.html
@@ -4,12 +4,12 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="/images/favicon/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta property="og:title" content="현대자동차 - 아반떼 N 2024 | 고성능 컴팩트 스포츠카" />
+    <meta property="og:title" content="현대자동차 - 아반떼 N 2024 출시 이벤트" />
     <meta property="og:description" content="2024년형 아반떼 N은 강력한 성능과 세련된 디자인을 자랑하는 스포츠 세단입니다. 혁신적인 기술과 향상된 드라이빙 경험을 지금 확인해 보세요!" />
     <meta property="og:image" content="/images/og/ogImg.png" />
     <meta property="og:url" content="watermelon-clap.web.app" />
     <meta property="og:type" content="website" />
-    <title>현대자동차 - 아반떼 N 2024 | 고성능 컴팩트 스포츠카</title>
+    <title>현대자동차 - 아반떼 N 2024 출시 이벤트</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
# 📗 작업 내용

### 이슈 내용
- 기존 og태그의 타이틀을 보았을 떄, 이벤트 페이지의 느낌이 약하다는 의견


### 변경 사항
- 타이틀 수정: 현대자동차 - 아반떼 N 2024 | 고성능 컴팩트 스포츠카 -> 현대자동차 - 아반떼 N 2024 출시 이벤트
<br/>


# ✏️ 리뷰어 멘션

- @thgee 
