### PR TITLE
hotfix: 아이폰에서 배너이미지가 화면에 꽉 차는 이슈

### DIFF
--- a/packages/service/src/components/main/Banner/Banner.css.ts
+++ b/packages/service/src/components/main/Banner/Banner.css.ts
@@ -23,7 +23,7 @@ export const bannerImg = ({ index, currentIndex }: IBannerImg) => css`
   object-fit: cover;
 
   ${mobile(css`
-    height: fit-content;
+    height: auto;
   `)}
 `;
 

--- a/packages/service/src/pages/NewCar/NewCar.css.ts
+++ b/packages/service/src/pages/NewCar/NewCar.css.ts
@@ -13,6 +13,6 @@ export const mainImg = css`
   object-fit: cover;
 
   ${mobile(css`
-    height: fit-content;
+    height: auto;
   `)}
 `;


### PR DESCRIPTION


# 📗 작업 내용

### 이슈 내용
- 아이폰에서 배너이미지가 화면에 가득 차는 이슈가 발생


### 변경 사항
- `height : fit-content` -> `height : auto` 로 수정

<br/>


# ✏️ 리뷰어 멘션

- @DaeWon9 
