### PR TITLE
__hotfix: GNB의 `active된 link`의 스타일링에 breakPoint 수정

### DIFF
--- a/packages/service/src/common/components/GlobalNavigationBar/GlobalNavs/GlobalNavs.css.ts
+++ b/packages/service/src/common/components/GlobalNavigationBar/GlobalNavs/GlobalNavs.css.ts
@@ -90,9 +90,12 @@ export const activeLinkStyles = css`
     border-radius: 1px;
   }
 
-  ${mobile(css`
-    &::after {
-      display: none;
-    }
-  `)}
+  ${mobile(
+    css`
+      &::after {
+        display: none;
+      }
+    `,
+    GNB_BREAKPOINT,
+  )}
 `;


### PR DESCRIPTION

# 📗 작업 내용

### 이슈 내용

<img width="477" alt="image" src="https://github.com/user-attachments/assets/8e47f27e-605e-444a-a801-3b5f0a764316">

- GNB에서 현재 페이지 표시의 `breakpoint` `GNB_BREAKPOINT` 가  아닌, `MOBILE_BREAKPOINT` 로 설정되어있던 이슈


### 변경 사항
- `breakpoint`를 `GNB_BREAKPOINT`로 변경

<br/>


# ✏️ 리뷰어 멘션

- @DaeWon9 
